### PR TITLE
fix: Fix unit tests that fail on Windows

### DIFF
--- a/pydantic_ai_skills/directory.py
+++ b/pydantic_ai_skills/directory.py
@@ -170,7 +170,7 @@ def _discover_resources(skill_folder: Path) -> list[SkillResource]:
                     continue
 
                 rel_path = resource_file.relative_to(skill_folder)
-                name = str(rel_path)
+                name = rel_path.as_posix()
                 resources.append(
                     create_file_based_resource(
                         name=name,
@@ -245,7 +245,7 @@ def _discover_scripts(
         rel_path = py_file.relative_to(skill_folder)
         scripts.append(
             create_file_based_script(
-                name=str(rel_path),
+                name = rel_path.as_posix(),
                 uri=str(resolved_path),
                 skill_name=skill_name,
                 executor=executor,

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,6 +1,7 @@
 """Tests for uncovered code paths to improve coverage."""
 
 import json
+import sys
 import warnings
 from pathlib import Path
 
@@ -281,6 +282,7 @@ Content
         assert 'Skipping invalid skill' in str(w[0].message)
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='chmod does not restrict file access on Windows')
 def test_discover_skills_os_error_handling(tmp_path: Path) -> None:
     """Test handling of OS errors during skill discovery."""
     skill_dir = tmp_path / 'skill'


### PR DESCRIPTION
1. use as_posix for for platform compatibility
2. skip running test_discover_skills_os_error_handling on windows
