### PR TITLE
feat: [DEV-1163] fix duplicated instructions in SkillsCapability

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "python-envs.defaultEnvManager": "ms-python.python:system"
+    "python-envs.defaultEnvManager": "ms-python.python:venv"
 }

--- a/pydantic_ai_skills/capability.py
+++ b/pydantic_ai_skills/capability.py
@@ -11,19 +11,20 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 if TYPE_CHECKING:
-    from pydantic_ai._instructions import AgentInstructions
+    from pydantic_ai.agent.abstract import AgentInstructions
     from pydantic_ai.tools import AgentDepsT, RunContext
 else:
+    try:
+        from pydantic_ai.agent.abstract import AgentInstructions
+    except ImportError:
+        AgentInstructions = Any
+
     try:
         from pydantic_ai.tools import AgentDepsT, RunContext
     except ImportError:
         AgentDepsT = Any
         RunContext = Any
 
-    try:
-        from pydantic_ai._instructions import AgentInstructions
-    except ImportError:
-        AgentInstructions = Any
 from .directory import SkillsDirectory
 from .registries._base import SkillRegistry
 from .toolset import SkillsToolset

--- a/pydantic_ai_skills/capability.py
+++ b/pydantic_ai_skills/capability.py
@@ -10,9 +10,20 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from pydantic_ai._instructions import AgentInstructions
-from pydantic_ai.tools import AgentDepsT, RunContext
+if TYPE_CHECKING:
+    from pydantic_ai._instructions import AgentInstructions
+    from pydantic_ai.tools import AgentDepsT, RunContext
+else:
+    try:
+        from pydantic_ai.tools import AgentDepsT, RunContext
+    except ImportError:
+        AgentDepsT = Any
+        RunContext = Any
 
+    try:
+        from pydantic_ai._instructions import AgentInstructions
+    except ImportError:
+        AgentInstructions = Any
 from .directory import SkillsDirectory
 from .registries._base import SkillRegistry
 from .toolset import SkillsToolset

--- a/pydantic_ai_skills/capability.py
+++ b/pydantic_ai_skills/capability.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from pydantic_ai.tools import RunContext
+from pydantic_ai._instructions import AgentInstructions
+from pydantic_ai.tools import AgentDepsT, RunContext
 
 from .directory import SkillsDirectory
 from .registries._base import SkillRegistry
@@ -105,10 +106,22 @@ class SkillsCapability(_AbstractCapabilityBase[Any]):
         """Return the underlying skills toolset."""
         return self._toolset
 
-    def get_instructions(self) -> Any:
-        """Return dynamic instructions via the underlying skills toolset."""
+    def get_instructions(self) -> AgentInstructions[AgentDepsT] | None:
+        """Return dynamic instructions via the underlying skills toolset.
 
-        async def _instructions(ctx: RunContext[Any]) -> str | None:
+        For pydantic-ai >= 1.74, instructions are natively extracted from the toolset
+        by the agent, so we return None here to avoid injecting duplicate instructions.
+        For older versions (pydantic-ai>=1.71), we return a function that delegates to the toolset.
+        """
+        try:
+            from pydantic_ai.toolsets import AbstractToolset
+
+            if hasattr(AbstractToolset, 'get_instructions'):
+                return None
+        except ImportError:
+            pass
+
+        async def _instructions(ctx: RunContext[AgentDepsT]) -> str | None:
             return await self._toolset.get_instructions(ctx)
 
         return _instructions

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib.util
-from types import SimpleNamespace
 
 import pytest
 
@@ -42,26 +41,6 @@ def test_skills_capability_runtime_error_when_flag_disabled(monkeypatch: pytest.
 
     with pytest.raises(RuntimeError, match='pydantic-ai>=1.71'):
         capability_module.SkillsCapability(skills=[], directories=[])
-
-
-@pytest.mark.asyncio
-async def test_skills_capability_get_instructions_delegates_to_toolset() -> None:
-    """get_instructions should delegate to the wrapped SkillsToolset method."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
-    capability = SkillsCapability(skills=[], directories=[])
-
-    async def _fake_get_instructions(ctx: object) -> str:
-        assert ctx is fake_ctx
-        return 'delegated-instructions'
-
-    fake_ctx = SimpleNamespace(deps=None)
-    capability.toolset.get_instructions = _fake_get_instructions  # type: ignore[method-assign]
-
-    instructions_provider = capability.get_instructions()
-    assert callable(instructions_provider)
-    assert await instructions_provider(fake_ctx) == 'delegated-instructions'
 
 
 def test_skills_capability_init_with_minimal_params() -> None:
@@ -114,36 +93,6 @@ def test_skills_capability_toolset_property_is_same_as_get_toolset() -> None:
     assert toolset_property is get_toolset_result
 
 
-@pytest.mark.asyncio
-async def test_skills_capability_get_instructions_returns_callable() -> None:
-    """get_instructions should always return a callable."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
-    capability = SkillsCapability(skills=[])
-    instructions_func = capability.get_instructions()
-    assert callable(instructions_func)
-
-
-@pytest.mark.asyncio
-async def test_skills_capability_get_instructions_with_none_return() -> None:
-    """get_instructions should handle None return from toolset."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
-    capability = SkillsCapability(skills=[])
-
-    async def _fake_get_instructions(ctx: object) -> None:
-        return None
-
-    fake_ctx = SimpleNamespace(deps=None)
-    capability.toolset.get_instructions = _fake_get_instructions  # type: ignore[method-assign]
-
-    instructions_provider = capability.get_instructions()
-    result = await instructions_provider(fake_ctx)
-    assert result is None
-
-
 def test_skills_capability_with_exclude_tools_as_list() -> None:
     """Constructor should accept exclude_tools as a list."""
     if not _capabilities_available():
@@ -167,3 +116,45 @@ def test_skills_capability_init_with_custom_template() -> None:
         instruction_template=template,
     )
     assert isinstance(capability.get_toolset(), SkillsToolset)
+
+
+@pytest.mark.asyncio
+async def test_skills_capability_get_instructions_delegates_when_no_toolset_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_instructions delegates when AbstractToolset.get_instructions is missing."""
+    if not _capabilities_available():
+        pytest.skip('Capabilities API is not available in this environment')
+
+    class MockToolset:
+        pass
+
+    monkeypatch.setattr('pydantic_ai.toolsets.AbstractToolset', MockToolset, raising=False)
+
+    capability = SkillsCapability(skills=[])
+
+    async def _fake_get_instructions(ctx: object) -> str:
+        return 'delegated-instructions'
+
+    capability.toolset.get_instructions = _fake_get_instructions  # type: ignore[method-assign]
+
+    instructions_provider = capability.get_instructions()
+    assert callable(instructions_provider)
+    assert await instructions_provider(None) == 'delegated-instructions'
+
+
+@pytest.mark.asyncio
+async def test_skills_capability_get_instructions_returns_none_when_has_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_instructions returns None when AbstractToolset implicitly has get_instructions."""
+    if not _capabilities_available():
+        pytest.skip('Capabilities API is not available in this environment')
+
+    class MockToolset:
+        def get_instructions(self) -> None:
+            pass
+
+    monkeypatch.setattr('pydantic_ai.toolsets.AbstractToolset', MockToolset, raising=False)
+
+    capability = SkillsCapability(skills=[])
+    instructions_provider = capability.get_instructions()
+    assert instructions_provider is None

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import builtins
 import importlib.util
+from typing import Any
 
 import pytest
 
@@ -158,3 +160,57 @@ async def test_skills_capability_get_instructions_returns_none_when_has_method(m
     capability = SkillsCapability(skills=[])
     instructions_provider = capability.get_instructions()
     assert instructions_provider is None
+
+
+@pytest.mark.asyncio
+async def test_skills_capability_get_instructions_handles_toolsets_importerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_instructions should delegate when importing pydantic_ai.toolsets fails."""
+    if not _capabilities_available():
+        pytest.skip('Capabilities API is not available in this environment')
+
+    capability = SkillsCapability(skills=[])
+
+    async def _fake_get_instructions(ctx: object) -> str:
+        _ = ctx
+        return 'delegated-on-importerror'
+
+    capability.toolset.get_instructions = _fake_get_instructions  # type: ignore[method-assign]
+
+    real_import = builtins.__import__
+
+    def _import_with_toolsets_error(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == 'pydantic_ai.toolsets':
+            raise ImportError('simulated toolsets import failure')
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', _import_with_toolsets_error)
+
+    instructions_provider = capability.get_instructions()
+    assert callable(instructions_provider)
+    assert await instructions_provider(None) == 'delegated-on-importerror'
+
+
+def test_capability_module_import_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Module-level fallback assignments should be used when pydantic-ai imports fail."""
+    real_import = builtins.__import__
+
+    def _import_with_failures(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name in {
+            'pydantic_ai.tools',
+            'pydantic_ai.agent.abstract',
+            'pydantic_ai.capabilities',
+        }:
+            raise ImportError(f'simulated import failure for {name}')
+        return real_import(name, *args, **kwargs)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(builtins, '__import__', _import_with_failures)
+        reloaded = importlib.reload(capability_module)
+
+    assert reloaded.AgentDepsT is Any
+    assert reloaded.RunContext is Any
+    assert reloaded.AgentInstructions is Any
+    assert reloaded._CAPABILITIES_AVAILABLE is False
+
+    # Restore the module state for later tests.
+    importlib.reload(capability_module)


### PR DESCRIPTION
This pull request updates the handling of dynamic agent instructions in the `SkillsCapability` class to ensure compatibility with different versions of `pydantic-ai`, and refactors related tests for improved coverage and accuracy.

Fixes #37 

**Core logic changes:**

- The `get_instructions` method in `SkillsCapability` now checks if the underlying `AbstractToolset` provides a native `get_instructions` method. If so (pydantic-ai >= 1.74), it returns `None` to avoid duplicate instructions; otherwise, it returns the instructions using the `SkillsToolset.get_instructions()` method for older versions.
- Imports in `pydantic_ai_skills/capability.py` are updated to include `AgentInstructions` and `AgentDepsT` for improved type safety.

**Testing improvements:**

- Old tests for `get_instructions` delegation and return value are removed, and new tests are added to cover both code paths: delegation when the toolset lacks `get_instructions`, and returning `None` when the method exists. [[1]](diffhunk://#diff-6fd8ff5ea2f568382e1568546fd4d4a25c4190591a71296dd46ab18727882634L47-L66) [[2]](diffhunk://#diff-6fd8ff5ea2f568382e1568546fd4d4a25c4190591a71296dd46ab18727882634L117-L146) [[3]](diffhunk://#diff-6fd8ff5ea2f568382e1568546fd4d4a25c4190591a71296dd46ab18727882634R119-R160)
- Minor cleanup in test imports (removal of unused `SimpleNamespace`).

**Development environment:**

- The default Python environment manager in `.vscode/settings.json` is switched from `system` to `venv` for improved isolation.