### PR TITLE
Add documentation for debugging skill scripts

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -384,6 +384,39 @@ def sync_script(ctx: RunContext[MyDeps]) -> str:
 
 ## Custom Script Executors
 
+### Debugging File-Based Scripts Locally
+
+File-based scripts discovered from skill directories run in a subprocess by default (`LocalSkillScriptExecutor`). For local development and debugging, you can switch to an in-process executor that uses `runpy.run_path` to execute script files directly in the same process. This allows you to set breakpoints and inspect variables with your IDE's debugger.
+
+```bash
+python -m examples.debug_local_logging
+```
+
+The example above:
+
+1. Creates a demo skill under `examples/tmp/debug-logging-skill`
+2. Uses `CallableSkillScriptExecutor` to run script files in-process with `runpy.run_path`
+3. Captures stdout/stderr and writes execution traces to `examples/tmp/debug-local-executor.log`
+
+Minimal pattern:
+
+```python
+from pydantic_ai_skills import CallableSkillScriptExecutor, SkillsDirectory
+
+async def in_process_executor(*, script, args=None):
+    # Development-only path for breakpoint debugging.
+    ...
+
+executor = CallableSkillScriptExecutor(func=in_process_executor)
+skills_dir = SkillsDirectory(path='./skills', script_executor=executor)
+```
+
+Important caveats:
+
+- **Not for production**: Running untrusted scripts in-process can be dangerous. Use this pattern only for local development with trusted code.
+- **Limited isolation**: In-process execution means scripts have access to the same memory and environment as your agent. Be cautious of side effects and security implications.
+- **Performance**: In-process execution may be faster for small scripts, but can lead to memory leaks or instability if the script misbehaves. Always test thoroughly when using custom executors.
+
 ### Creating Custom Executors
 
 For advanced use cases, you can provide custom script executors that handle script execution differently than the built-in local executor. This enables:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-This folder contains runnable examples demonstrating how to use `pydantic-ai-skills` in different scenarios. Each script spins up a Pydantic AI agent as a web server using [uvicorn](https://www.uvicorn.org/) on `http://127.0.0.1:7932`.
+This folder contains runnable examples demonstrating how to use `pydantic-ai-skills` in different scenarios. Most scripts spin up a Pydantic AI agent as a web server using [uvicorn](https://www.uvicorn.org/) on `http://127.0.0.1:7932`.
 
 ## Contents
 
@@ -10,6 +10,7 @@ This folder contains runnable examples demonstrating how to use `pydantic-ai-ski
 | `advanced_usage.py` | Multiple skills directories, DuckDuckGo search tool, `httpx` URL fetcher, and a filesystem sandbox. |
 | `git_registry_usage.py` | Loads skills from a remote Git repository using `GitSkillsRegistry` (clones Anthropic's public skills repo). |
 | `programatic_skills.py` | Defines a skill entirely in Python using `@skill.resource` / `@skill.script` decorators — HR Analytics Agent backed by a HuggingFace dataset. |
+| `debug_local_logging.py` | Development-focused example that runs file-based skill scripts in-process for breakpoint debugging and writes a local execution log file. |
 
 ### Bundled skills
 

--- a/examples/debug_local_logging.py
+++ b/examples/debug_local_logging.py
@@ -1,0 +1,148 @@
+"""Debug file-based skill scripts in-process with local logging.
+
+This example demonstrates a development-only pattern for debugging script files
+with breakpoints by replacing subprocess execution with an in-process callable
+executor. It also writes a local execution log for quick diagnostics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import runpy
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pydantic_ai_skills import CallableSkillScriptExecutor, SkillsDirectory
+
+EXAMPLES_DIR = Path(__file__).parent
+TMP_DIR = EXAMPLES_DIR / 'tmp'
+SKILL_DIR = TMP_DIR / 'debug-logging-skill'
+LOG_FILE = TMP_DIR / 'debug-local-executor.log'
+
+
+def _append_log(message: str) -> None:
+    """Append one line to the local debug log file."""
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    with LOG_FILE.open('a', encoding='utf-8') as f:
+        f.write(f'[{timestamp}] {message}\n')
+
+
+def _write_demo_skill_files() -> Path:
+    """Create a self-contained demo skill used by this example."""
+    scripts_dir = SKILL_DIR / 'scripts'
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+
+    skill_md = """---
+name: debug-logging-skill
+description: Skill used to demonstrate in-process debugging for scripts.
+---
+
+Use this skill to test local script execution while debugging.
+"""
+
+    script_py = """#!/usr/bin/env python3
+import json
+import sys
+
+
+def main() -> None:
+    # Set a breakpoint on the line below when running this example in a debugger.
+    payload = {
+        'argv': sys.argv[1:],
+        'message': 'Script executed in-process',
+    }
+    print(json.dumps(payload))
+
+
+if __name__ == '__main__':
+    main()
+"""
+
+    (SKILL_DIR / 'SKILL.md').write_text(skill_md, encoding='utf-8')
+    script_path = scripts_dir / 'echo_args.py'
+    script_path.write_text(script_py, encoding='utf-8')
+    return script_path
+
+
+def _args_to_argv(args: dict[str, Any] | None) -> list[str]:
+    """Convert named args into CLI-style arguments for the script."""
+    if not args:
+        return []
+
+    argv: list[str] = []
+    for key, value in args.items():
+        argv.append(f'--{key}')
+        if isinstance(value, dict | list | tuple):
+            argv.append(json.dumps(value))
+        else:
+            argv.append(str(value))
+    return argv
+
+
+async def _in_process_executor(*, script: Any, args: dict[str, Any] | None = None) -> str:
+    """Run a discovered script file in-process and capture output.
+
+    This is intentionally development-oriented and mirrors subprocess behavior
+    only enough for local debugging and trace logging.
+    """
+    # Keep this executor async to match common custom executor signatures.
+    await asyncio.sleep(0)
+
+    if not getattr(script, 'uri', None):
+        raise ValueError('Script has no URI')
+
+    script_uri = str(script.uri)
+    argv = _args_to_argv(args)
+    _append_log(f'start script={script.name} uri={script_uri} args={args or {}}')
+
+    stdout_stream = io.StringIO()
+    stderr_stream = io.StringIO()
+    original_argv = sys.argv[:]
+
+    try:
+        sys.argv = [script_uri, *argv]
+        with redirect_stdout(stdout_stream), redirect_stderr(stderr_stream):
+            runpy.run_path(script_uri, run_name='__main__')
+    finally:
+        sys.argv = original_argv
+
+    stdout_output = stdout_stream.getvalue().strip()
+    stderr_output = stderr_stream.getvalue().strip()
+    _append_log(f'finish script={script.name} stdout_len={len(stdout_output)} stderr_len={len(stderr_output)}')
+
+    if stdout_output and stderr_output:
+        return f'{stdout_output}\nSTDERR:\n{stderr_output}'
+    return stdout_output or stderr_output or ''
+
+
+async def main() -> None:
+    """Run the demo skill script with an in-process callable executor."""
+    script_path = _write_demo_skill_files()
+
+    # Clear previous run logs for a clean demonstration.
+    if LOG_FILE.exists():
+        LOG_FILE.unlink()
+
+    executor = CallableSkillScriptExecutor(func=_in_process_executor)
+    skills_dir = SkillsDirectory(path=TMP_DIR, script_executor=executor, validate=True)
+
+    skill = skills_dir.load_skill(str(SKILL_DIR.resolve()))
+    script = next(s for s in skill.scripts if s.name.endswith('echo_args.py'))
+
+    output = await script.run(None, args={'query': 'debug', 'limit': 3})
+
+    print('Debug demo finished.')
+    print(f'Script file: {script_path}')
+    print(f'Log file: {LOG_FILE}')
+    print('Script output:')
+    print(output)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/examples/debug_local_logging.py
+++ b/examples/debug_local_logging.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import os
 import runpy
 import sys
 from contextlib import redirect_stderr, redirect_stdout
@@ -23,6 +24,7 @@ EXAMPLES_DIR = Path(__file__).parent
 TMP_DIR = EXAMPLES_DIR / 'tmp'
 SKILL_DIR = TMP_DIR / 'debug-logging-skill'
 LOG_FILE = TMP_DIR / 'debug-local-executor.log'
+_JSON_ARG_TYPES = (dict, list, tuple)
 
 
 def _append_log(message: str) -> None:
@@ -71,14 +73,31 @@ if __name__ == '__main__':
 
 
 def _args_to_argv(args: dict[str, Any] | None) -> list[str]:
-    """Convert named args into CLI-style arguments for the script."""
+    """Convert args using LocalSkillScriptExecutor-style CLI semantics."""
     if not args:
         return []
 
     argv: list[str] = []
     for key, value in args.items():
+        if isinstance(value, bool):
+            if value:
+                argv.append(f'--{key}')
+            continue
+
+        if isinstance(value, list):
+            for item in value:
+                argv.append(f'--{key}')
+                if isinstance(item, _JSON_ARG_TYPES):
+                    argv.append(json.dumps(item))
+                else:
+                    argv.append(str(item))
+            continue
+
+        if value is None:
+            continue
+
         argv.append(f'--{key}')
-        if isinstance(value, dict | list | tuple):
+        if isinstance(value, _JSON_ARG_TYPES):
             argv.append(json.dumps(value))
         else:
             argv.append(str(value))
@@ -104,15 +123,24 @@ async def _in_process_executor(*, script: Any, args: dict[str, Any] | None = Non
     stdout_stream = io.StringIO()
     stderr_stream = io.StringIO()
     original_argv = sys.argv[:]
+    original_cwd = os.getcwd()
+    script_dir = str(Path(script_uri).parent)
+    exit_note = ''
 
     try:
         sys.argv = [script_uri, *argv]
+        os.chdir(script_dir)
         with redirect_stdout(stdout_stream), redirect_stderr(stderr_stream):
-            runpy.run_path(script_uri, run_name='__main__')
+            try:
+                runpy.run_path(script_uri, run_name='__main__')
+            except SystemExit as e:
+                code = e.code if e.code is not None else 0
+                exit_note = f'\nSystemExit: {code}'
     finally:
         sys.argv = original_argv
+        os.chdir(original_cwd)
 
-    stdout_output = stdout_stream.getvalue().strip()
+    stdout_output = stdout_stream.getvalue().strip() + exit_note
     stderr_output = stderr_stream.getvalue().strip()
     _append_log(f'finish script={script.name} stdout_len={len(stdout_output)} stderr_len={len(stderr_output)}')
 


### PR DESCRIPTION
This pull request introduces a new example for debugging file-based skill scripts in-process, updates the documentation to explain this development pattern, and adds a reference to the example in the examples README. The main goal is to help developers debug scripts with breakpoints and local logging, while highlighting important caveats about in-process execution.

Fixes #23

**New debugging example:**

* Added `examples/debug_local_logging.py`, which demonstrates running skill scripts in-process via `CallableSkillScriptExecutor`, allowing for breakpoint debugging and capturing execution logs in `examples/tmp/debug-local-executor.log`. The example creates a demo skill, runs a script with arguments, and logs output for diagnostics.

**Documentation updates:**

* Updated `docs/advanced.md` to add a new section, "Debugging File-Based Scripts Locally," explaining how to use an in-process executor for development, with code snippets, usage instructions, and warnings about production safety and isolation.

**Examples index update:**

* Updated `examples/README.md` to reference the new `debug_local_logging.py` example, clarifying that most examples run as web servers, and describing the new example’s focus on in-process debugging and local logging. [[1]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L3-R3) [[2]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9R13)