### PR TITLE
DEV-1192: drop pre-1.74 pydantic-ai compatibility shims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Core boundaries:
 - Type layer (dataclasses and normalization): [pydantic_ai_skills/types.py](pydantic_ai_skills/types.py)
 - Tool integration layer: [pydantic_ai_skills/toolset.py](pydantic_ai_skills/toolset.py)
 - Local execution and script dispatch: [pydantic_ai_skills/local.py](pydantic_ai_skills/local.py)
-- Capability adapter for pydantic-ai >=1.71: [pydantic_ai_skills/capability.py](pydantic_ai_skills/capability.py)
+- Capability adapter: [pydantic_ai_skills/capability.py](pydantic_ai_skills/capability.py)
 - Registry implementations and composition wrappers: [pydantic_ai_skills/registries/](pydantic_ai_skills/registries/)
 
 Behavioral constraints to preserve:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Create dynamic skills with Python:
 
 ## Quick Start
 
-If you are using `pydantic-ai>=1.71`, we recommend using `SkillsCapability`, which is based on the Pydantic AI [Capabilities API](https://ai.pydantic.dev/capabilities/). It bundles the skills tools and instructions into a single object that can be added to agents. This provides a more streamlined and integrated way to use agent skills.
+We recommend using `SkillsCapability`, which is based on the Pydantic AI [Capabilities API](https://ai.pydantic.dev/capabilities/). It bundles the skills tools and instructions into a single object that can be added to agents. This provides a more streamlined and integrated way to use agent skills.
 
 ```python
 from pydantic_ai import Agent
@@ -78,10 +78,10 @@ agent = Agent(
 )
 ```
 
-For earlier versions of Pydantic AI, you can use the `SkillsToolset`.
+Alternatively, use `SkillsToolset` directly when your app is built around `toolsets=[...]`.
 
 ```python
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent
 from pydantic_ai_skills import SkillsToolset
 
 # Initialize Skills Toolset with one or more skill directories
@@ -93,13 +93,6 @@ agent = Agent(
     instructions='You are a helpful research assistant.',
     toolsets=[skills_toolset]
 )
-
-# For pydantic-ai<1.74, you must add an instructions hook to inject the skills instructions into the agent's context
-# On pydantic-ai >= 1.74, this is automatic and you can omit the following instructions hook
-# @agent.instructions
-# async def add_skills(ctx: RunContext) -> str | None:
-#     """Add skills instructions to the agent's context."""
-#     return await skills_toolset.get_instructions(ctx)
 
 # Use agent - skills tools are available for the agent to call
 user_prompt = "What are the last 3 papers on arXiv about machine learning?"

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -14,7 +14,7 @@ Watch the Advanced Usage Tutorial for in-depth demonstrations of advanced skill 
 
 ## Hot-Reload (Runtime Skill Discovery)
 
-`SkillsCapability` is the preferred integration path on pydantic-ai >= 1.71. This section focuses on `SkillsToolset` because hot-reload controls (`reload()`, `auto_reload`) are configured on the underlying toolset.
+`SkillsCapability` is the preferred integration path. This section focuses on `SkillsToolset` because hot-reload controls (`reload()`, `auto_reload`) are configured on the underlying toolset.
 
 Long-lived server processes (FastAPI, Starlette, etc.) may need to pick up skill edits — made by the agent itself, a git-sync job, or a human — without restarting. `SkillsToolset` supports this via `reload()` and the `auto_reload` parameter.
 

--- a/docs/api/capability.md
+++ b/docs/api/capability.md
@@ -2,9 +2,7 @@
 
 `SkillsCapability` integrates pydantic-ai-skills with Pydantic AI's capabilities API.
 
-For pydantic-ai >= 1.71, this is the preferred integration path.
-
-Use this when your agent uses `capabilities=[...]`.
+This is the preferred integration path. Use it when your agent uses `capabilities=[...]`.
 
 ::: pydantic_ai_skills.capability.SkillsCapability
     options:

--- a/docs/api/toolset.md
+++ b/docs/api/toolset.md
@@ -1,11 +1,8 @@
 # SkillsToolset API Reference
 
-For pydantic-ai >= 1.71, prefer [SkillsCapability API](capability.md).
+Prefer the [SkillsCapability API](capability.md) when your app uses `capabilities=[...]`.
 
-When using `SkillsToolset` directly:
-
-- For pydantic-ai < 1.74, you must add an instructions hook to inject the skills instructions into the agent's context.
-- On pydantic-ai >= 1.74, this is automatic.
+When using `SkillsToolset` directly with `toolsets=[...]`, skill instructions are injected into the agent's context automatically.
 
 ::: pydantic_ai_skills.toolset.SkillsToolset
 options:
@@ -38,7 +35,7 @@ The `SkillsToolset.__init__()` accepts the following parameters:
 | Method | Description |
 |--------|-------------|
 | `get_skill(skill_name: str) -> Skill` | Retrieve a specific skill by name. Raises `SkillNotFoundError` if not found. |
-| `get_instructions(ctx: RunContext[Any]) -> str | None` | Returns formatted system prompt with skills instructions, or `None` if no skills are loaded. Called automatically on pydantic-ai >= 1.74. |
+| `get_instructions(ctx: RunContext[Any]) -> str | None` | Returns formatted system prompt with skills instructions, or `None` if no skills are loaded. Called automatically by the agent. |
 
 ## Usage Examples
 
@@ -218,7 +215,7 @@ Load the full skill with `load_skill` to see available resources and scripts.
 ### Get Skills Instructions for Agent
 
 ```python
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent
 from pydantic_ai_skills import SkillsToolset
 
 toolset = SkillsToolset(directories=["./skills"])
@@ -229,14 +226,7 @@ agent = Agent(
     toolsets=[toolset]
 )
 
-# For pydantic-ai<1.74, you must add an instructions hook to inject the skills instructions into the agent's context
-# On pydantic-ai >= 1.74, this is automatic and you can omit the following instructions hook
-# @agent.instructions
-# async def add_skills(ctx: RunContext) -> str | None:
-#     """Inject skills instructions into agent context."""
-#     return await toolset.get_instructions(ctx)
-
-# The agent will receive skill metadata in system prompt
+# Skill instructions are injected into the agent's system prompt automatically.
 result = agent.run_sync('Analyze the quarterly data')
 ```
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -36,27 +36,18 @@ Skills can also be loaded from remote sources via **skill registries**. For exam
 
 You can integrate skills in two ways:
 
-1. `SkillsToolset` (works across supported pydantic-ai versions)
-2. `SkillsCapability` (uses the `capabilities=[...]` API in pydantic-ai >= 1.71)
+1. `SkillsToolset` (uses the `toolsets=[...]` API)
+2. `SkillsCapability` (uses the `capabilities=[...]` API)
 
-For pydantic-ai >= 1.71, prefer `SkillsCapability`.
-
-`SkillsCapability` wraps an internal `SkillsToolset` so behavior is consistent across both approaches, and it bundles instruction injection automatically through the Capability API.
+`SkillsCapability` is the preferred integration path. It wraps an internal `SkillsToolset` so behavior is consistent across both approaches, and it bundles instruction injection through the Capability API.
 
 ### SkillsToolset mode
 
-Use this mode when your app is built around `toolsets=[...]`.
-
-When using `SkillsToolset` directly:
-
-- For pydantic-ai < 1.74, you must add an instructions hook to inject the skills instructions into the agent's context.
-- On pydantic-ai >= 1.74, this is automatic.
+Use this mode when your app is built around `toolsets=[...]`. Skills instructions are injected into the agent's context automatically.
 
 ### SkillsCapability mode
 
-Use this mode when your app is built around `capabilities=[...]`.
-
-This is the recommended mode on pydantic-ai >= 1.71 because skills tools and skills instructions are bundled in one capability.
+Use this mode when your app is built around `capabilities=[...]`. Skills tools and skills instructions are bundled in one capability.
 
 ```python
 from pydantic_ai import Agent

--- a/docs/creating-skills.md
+++ b/docs/creating-skills.md
@@ -740,7 +740,7 @@ Test with a real agent:
 
 ```python
 import asyncio
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent
 from pydantic_ai_skills import SkillsToolset
 
 async def test_skill():
@@ -751,13 +751,6 @@ async def test_skill():
         instructions="You are a test assistant.",
         toolsets=[toolset]
     )
-
-    # For pydantic-ai<1.74, you must add an instructions hook to inject the skills instructions into the agent's context
-    # On pydantic-ai >= 1.74, this is automatic and you can omit the following instructions hook
-    # @agent.instructions
-    # async def add_skills(ctx: RunContext) -> str | None:
-    #     """Add skills instructions to the agent's context."""
-    #     return await toolset.get_instructions(ctx)
 
     result = await agent.run("Test my-skill with input: test data")
     print(result.output)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Agent Skills are **modular collections of instructions, scripts, and resources**
 - **Resource Management**: Support for documentation and data files
 - **Type-Safe**: Built on Pydantic AI's type-safe foundation
 - **Simple Integration**: Drop-in toolset for Pydantic AI agents
-- **Capabilities Integration**: Preferred on pydantic-ai >= 1.71 via `SkillsCapability` and `capabilities=[...]`
+- **Capabilities Integration**: Preferred via `SkillsCapability` and `capabilities=[...]`
 
 ## Quick Example
 
@@ -23,7 +23,7 @@ Agent Skills are **modular collections of instructions, scripts, and resources**
 from pydantic_ai import Agent
 from pydantic_ai_skills import SkillsCapability
 
-# Create agent with skills (preferred on pydantic-ai >= 1.71)
+# Create agent with skills
 agent = Agent(
     model='openai:gpt-5.2',
     instructions="You are a helpful research assistant.",
@@ -37,15 +37,12 @@ result = await agent.run(
 print(result.output)
 ```
 
-## Capabilities API Example (pydantic-ai >= 1.71)
+## Capabilities API Example
 
-`SkillsCapability` is the preferred integration path on pydantic-ai >= 1.71.
+`SkillsCapability` is the preferred integration path.
 
 It bundles `SkillsToolset` behavior and instruction injection through Pydantic AI's Capability API.
-If you use `SkillsToolset` directly:
-
-- For pydantic-ai < 1.74, you must add an instructions hook to inject the skills instructions into the agent's context.
-- On pydantic-ai >= 1.74, this is automatic.
+If you use `SkillsToolset` directly, instructions are injected automatically.
 
 ```python
 from pydantic_ai import Agent
@@ -61,10 +58,10 @@ agent = Agent(
 
 ## Direct SkillsToolset Example
 
-For earlier versions of Pydantic AI, you can use `SkillsToolset`.
+You can also use `SkillsToolset` directly when you need explicit control.
 
 ```python
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent
 from pydantic_ai_skills import SkillsToolset
 
 skills_toolset = SkillsToolset(directories=['./skills'])
@@ -74,12 +71,6 @@ agent = Agent(
     instructions='You are a helpful research assistant.',
     toolsets=[skills_toolset],
 )
-
-# For pydantic-ai<1.74, you must add an instructions hook to inject the skills instructions into the agent's context
-# On pydantic-ai >= 1.74, this is automatic and you can omit the following instructions hook
-# @agent.instructions
-# async def add_skills(ctx: RunContext) -> str | None:
-#     return await skills_toolset.get_instructions(ctx)
 ```
 
 ## How It Works

--- a/docs/programmatic-skills.md
+++ b/docs/programmatic-skills.md
@@ -14,7 +14,7 @@ Learn how to create programmatic skills by watching the Programmatic Skills Tuto
 
 ## Overview
 
-For pydantic-ai >= 1.71, prefer integrating programmatic skills through `SkillsCapability` and `capabilities=[...]`. Use `SkillsToolset` directly when you need explicit/manual control over instruction wiring.
+Prefer integrating programmatic skills through `SkillsCapability` and `capabilities=[...]`. Use `SkillsToolset` directly when your app is built around `toolsets=[...]`.
 
 Programmatic skills let you:
 
@@ -66,22 +66,15 @@ agent = Agent(
 
 ### Direct SkillsToolset Integration
 
-For pydantic-ai < 1.74, you must add an instructions hook to inject the skills instructions into the agent's context.
-On pydantic-ai >= 1.74, this is automatic.
+Skill instructions are injected into the agent's context automatically.
 
 ```python
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent
 
 agent = Agent(
     model='openai:gpt-5.2',
     toolsets=[skills_toolset],
 )
-
-# For pydantic-ai<1.74, you must add an instructions hook to inject the skills instructions into the agent's context
-# On pydantic-ai >= 1.74, this is automatic and you can omit the following instructions hook
-# @agent.instructions
-# async def add_skills(ctx: RunContext) -> str | None:
-#     return await skills_toolset.get_instructions(ctx)
 ```
 
 ## Adding Dynamic Resources

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -75,7 +75,7 @@ async def my_tool(ctx: RunContext[str]) -> str:
 
 ### 2. Create an Agent with Skills
 
-For pydantic-ai >= 1.71, use `SkillsCapability` as the default integration path.
+Use `SkillsCapability` as the default integration path.
 
 Create `agent.py`:
 
@@ -97,14 +97,13 @@ print(result.output)
 ### Alternative: Direct SkillsToolset
 
 Use direct `SkillsToolset` integration when your app is built around `toolsets=[...]`.
-For pydantic-ai < 1.74, you must add an instructions hook to inject the skills instructions into the agent's context.
-On pydantic-ai >= 1.74, this is automatic.
+Skill instructions are injected into the agent's context automatically.
 
 Create `agent.py`:
 
 ```python
 import asyncio
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent
 from pydantic_ai_skills import SkillsToolset
 
 async def main():
@@ -117,13 +116,6 @@ async def main():
         instructions="You are a helpful assistant.",
         toolsets=[skills_toolset]
     )
-
-    # For pydantic-ai<1.74, you must add an instructions hook to inject the skills instructions into the agent's context
-    # On pydantic-ai >= 1.74, this is automatic and you can omit the following instructions hook
-    # @agent.instructions
-    # async def add_skills(ctx: RunContext) -> str | None:
-    #     """Add skills instructions to the agent's context."""
-    #     return await skills_toolset.get_instructions(ctx)
 
     # Run the agent
     result = await agent.run("How do I create a Pydantic AI agent with tools?")
@@ -153,7 +145,7 @@ When you initialize skills support (via `SkillsCapability` or `SkillsToolset`):
 
 1. **Discovery**: Scans `./skills/` for skill directories with `SKILL.md` files
 2. **Registration**: Registers four tools (`list_skills`, `load_skill`, `read_skill_resource`, `run_skill_script`)
-3. **Instructions**: Skills overview is added automatically (`SkillsCapability` always; `SkillsToolset` on pydantic-ai >= 1.74). For pydantic-ai < 1.74 with `SkillsToolset`, add a manual compatibility hook.
+3. **Instructions**: Skills overview is added automatically by both `SkillsCapability` and `SkillsToolset`.
 4. **Execution**: Agent discovers, loads, and uses skills as needed
 
 ## Add a Script-Based Skill

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -37,7 +37,7 @@ agent = Agent(
 ### Direct SkillsToolset Integration
 
 ```python
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent
 from pydantic_ai_skills import SkillsToolset
 
 skills_toolset = SkillsToolset(registries=[registry])
@@ -47,12 +47,6 @@ agent = Agent(
     instructions='You are a helpful assistant with access to a variety of skills.',
     toolsets=[skills_toolset],
 )
-
-# For pydantic-ai<1.74, you must add an instructions hook to inject the skills instructions into the agent's context
-# On pydantic-ai >= 1.74, this is automatic and you can omit the following instructions hook
-# @agent.instructions
-# async def add_skills(ctx: RunContext) -> str | None:
-#     return await skills_toolset.get_instructions(ctx)
 ```
 
 **View the complete example:** [git_registry_usage.py](https://github.com/DougTrajano/pydantic-ai-skills/blob/main/examples/git_registry_usage.py)

--- a/examples/README.md
+++ b/examples/README.md
@@ -71,8 +71,3 @@ python -m examples.basic_usage
 ```
 
 The agent will be available at `http://127.0.0.1:7932`.
-
-## Compatibility Note
-
-- On pydantic-ai >= 1.74, `SkillsToolset.get_instructions()` is injected automatically by the agent graph.
-- On pydantic-ai < 1.74, add a manual `@agent.instructions` hook that returns `await SkillsToolset.get_instructions(ctx)`.

--- a/pydantic_ai_skills/capability.py
+++ b/pydantic_ai_skills/capability.py
@@ -1,58 +1,28 @@
 """Capability integration for pydantic-ai-skills.
 
 This module provides [`SkillsCapability`][pydantic_ai_skills.SkillsCapability],
-an alternative integration path for Pydantic AI users on versions that support
-the capabilities API (pydantic-ai >= 1.71).
+the preferred integration path for Pydantic AI users via the `capabilities=[...]` API.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import Any
 
-if TYPE_CHECKING:
-    from pydantic_ai.agent.abstract import AgentInstructions
-    from pydantic_ai.tools import AgentDepsT, RunContext
-else:
-    try:
-        from pydantic_ai.agent.abstract import AgentInstructions
-    except ImportError:
-        AgentInstructions = Any
-
-    try:
-        from pydantic_ai.tools import AgentDepsT, RunContext
-    except ImportError:
-        AgentDepsT = Any
-        RunContext = Any
+from pydantic_ai.agent.abstract import AgentInstructions
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.tools import AgentDepsT
 
 from .directory import SkillsDirectory
 from .registries._base import SkillRegistry
 from .toolset import SkillsToolset
 from .types import Skill
 
-_AgentDepsT = TypeVar('_AgentDepsT')
 
-if TYPE_CHECKING:
-    from pydantic_ai.capabilities import AbstractCapability as _AbstractCapabilityBase
-
-    _CAPABILITIES_AVAILABLE = True
-else:
-    try:
-        from pydantic_ai.capabilities import AbstractCapability as _AbstractCapabilityBase
-
-        _CAPABILITIES_AVAILABLE = True
-    except ImportError:
-        _CAPABILITIES_AVAILABLE = False
-
-        class _AbstractCapabilityBase(Generic[_AgentDepsT]):
-            """Fallback placeholder when pydantic-ai capabilities are unavailable."""
-
-
-class SkillsCapability(_AbstractCapabilityBase[Any]):
+class SkillsCapability(AbstractCapability[Any]):
     """Capability wrapper for `SkillsToolset`.
 
-    Use this class with the agent `capabilities=[...]` API introduced in
-    pydantic-ai 1.71+.
+    Use this class with the agent `capabilities=[...]` API.
 
     Example:
         ```python
@@ -91,17 +61,7 @@ class SkillsCapability(_AbstractCapabilityBase[Any]):
             instruction_template: Optional custom instructions template.
             exclude_tools: Tool names to exclude.
             auto_reload: Re-scan directories before each run.
-
-        Raises:
-            RuntimeError: If capabilities API is unavailable in installed
-                pydantic-ai version.
         """
-        if not _CAPABILITIES_AVAILABLE:
-            raise RuntimeError(
-                'SkillsCapability requires pydantic-ai>=1.71 with capabilities support. '
-                'Use SkillsToolset instead or upgrade pydantic-ai.'
-            )
-
         self._toolset = SkillsToolset(
             skills=skills,
             directories=directories,
@@ -119,24 +79,8 @@ class SkillsCapability(_AbstractCapabilityBase[Any]):
         return self._toolset
 
     def get_instructions(self) -> AgentInstructions[AgentDepsT] | None:
-        """Return dynamic instructions via the underlying skills toolset.
-
-        For pydantic-ai >= 1.74, instructions are natively extracted from the toolset
-        by the agent, so we return None here to avoid injecting duplicate instructions.
-        For older versions (pydantic-ai>=1.71), we return a function that delegates to the toolset.
-        """
-        try:
-            from pydantic_ai.toolsets import AbstractToolset
-
-            if hasattr(AbstractToolset, 'get_instructions'):
-                return None
-        except ImportError:
-            pass
-
-        async def _instructions(ctx: RunContext[AgentDepsT]) -> str | None:
-            return await self._toolset.get_instructions(ctx)
-
-        return _instructions
+        """Return None — instructions are pulled natively from the toolset by the agent."""
+        return None
 
     @property
     def toolset(self) -> SkillsToolset:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "anyio>=4.0.0",
-    "pydantic-ai-slim>=0.5.0",
+    "pydantic-ai-slim>=1.74",
     "pyyaml>=6.0",
 ]
 

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from pydantic_ai_skills import SkillsCapability, SkillsToolset
@@ -28,11 +30,14 @@ def test_skills_capability_init_with_directories() -> None:
     assert isinstance(capability.get_toolset(), SkillsToolset)
 
 
-def test_skills_capability_init_with_all_params(tmp_path: object) -> None:
+def test_skills_capability_init_with_all_params(tmp_path: Path) -> None:
     """Constructor should accept all parameters."""
+    skills_dir = tmp_path / 'skills'
+    skills_dir.mkdir()
+
     capability = SkillsCapability(
         skills=[],
-        directories=['./skills'],
+        directories=[skills_dir],
         registries=[],
         validate=False,
         max_depth=5,

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -2,34 +2,13 @@
 
 from __future__ import annotations
 
-import builtins
-import importlib.util
-from typing import Any
-
 import pytest
 
-import pydantic_ai_skills.capability as capability_module
 from pydantic_ai_skills import SkillsCapability, SkillsToolset
 
 
-def _capabilities_available() -> bool:
-    return importlib.util.find_spec('pydantic_ai.capabilities') is not None
-
-
-def test_skills_capability_legacy_runtime_error() -> None:
-    """Legacy pydantic-ai versions should fail with a clear message."""
-    if _capabilities_available():
-        pytest.skip('Capabilities API is available in this environment')
-
-    with pytest.raises(RuntimeError, match='pydantic-ai>=1.71'):
-        SkillsCapability(skills=[], directories=[])
-
-
-def test_skills_capability_get_toolset_when_available() -> None:
-    """Capabilities-enabled versions should return a SkillsToolset."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
+def test_skills_capability_get_toolset() -> None:
+    """SkillsCapability should expose a SkillsToolset."""
     capability = SkillsCapability(skills=[], directories=[])
     toolset = capability.get_toolset()
 
@@ -37,37 +16,20 @@ def test_skills_capability_get_toolset_when_available() -> None:
     assert capability.toolset is toolset
 
 
-def test_skills_capability_runtime_error_when_flag_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Constructor should fail with a clear error when capability support is disabled."""
-    monkeypatch.setattr(capability_module, '_CAPABILITIES_AVAILABLE', False)
-
-    with pytest.raises(RuntimeError, match='pydantic-ai>=1.71'):
-        capability_module.SkillsCapability(skills=[], directories=[])
-
-
 def test_skills_capability_init_with_minimal_params() -> None:
     """Constructor should work with only skills parameter."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
     capability = SkillsCapability(skills=[])
     assert isinstance(capability.get_toolset(), SkillsToolset)
 
 
 def test_skills_capability_init_with_directories() -> None:
     """Constructor should accept directories parameter."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
     capability = SkillsCapability(directories=['./skills'])
     assert isinstance(capability.get_toolset(), SkillsToolset)
 
 
 def test_skills_capability_init_with_all_params(tmp_path: object) -> None:
     """Constructor should accept all parameters."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
     capability = SkillsCapability(
         skills=[],
         directories=['./skills'],
@@ -86,9 +48,6 @@ def test_skills_capability_init_with_all_params(tmp_path: object) -> None:
 
 def test_skills_capability_toolset_property_is_same_as_get_toolset() -> None:
     """Toolset property should be the same instance as get_toolset()."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
     capability = SkillsCapability(skills=[])
     toolset_property = capability.toolset
     get_toolset_result = capability.get_toolset()
@@ -97,9 +56,6 @@ def test_skills_capability_toolset_property_is_same_as_get_toolset() -> None:
 
 def test_skills_capability_with_exclude_tools_as_list() -> None:
     """Constructor should accept exclude_tools as a list."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
     capability = SkillsCapability(
         skills=[],
         exclude_tools=['load_skill', 'run_skill_script'],
@@ -109,9 +65,6 @@ def test_skills_capability_with_exclude_tools_as_list() -> None:
 
 def test_skills_capability_init_with_custom_template() -> None:
     """Constructor should accept custom instruction template."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
     template = 'Use these skills: {skills_list}'
     capability = SkillsCapability(
         skills=[],
@@ -121,96 +74,7 @@ def test_skills_capability_init_with_custom_template() -> None:
 
 
 @pytest.mark.asyncio
-async def test_skills_capability_get_instructions_delegates_when_no_toolset_method(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """get_instructions delegates when AbstractToolset.get_instructions is missing."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
-    class MockToolset:
-        pass
-
-    monkeypatch.setattr('pydantic_ai.toolsets.AbstractToolset', MockToolset, raising=False)
-
+async def test_skills_capability_get_instructions_returns_none() -> None:
+    """get_instructions returns None — agent extracts instructions natively from the toolset."""
     capability = SkillsCapability(skills=[])
-
-    async def _fake_get_instructions(ctx: object) -> str:
-        return 'delegated-instructions'
-
-    capability.toolset.get_instructions = _fake_get_instructions  # type: ignore[method-assign]
-
-    instructions_provider = capability.get_instructions()
-    assert callable(instructions_provider)
-    assert await instructions_provider(None) == 'delegated-instructions'
-
-
-@pytest.mark.asyncio
-async def test_skills_capability_get_instructions_returns_none_when_has_method(monkeypatch: pytest.MonkeyPatch) -> None:
-    """get_instructions returns None when AbstractToolset implicitly has get_instructions."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
-    class MockToolset:
-        def get_instructions(self) -> None:
-            pass
-
-    monkeypatch.setattr('pydantic_ai.toolsets.AbstractToolset', MockToolset, raising=False)
-
-    capability = SkillsCapability(skills=[])
-    instructions_provider = capability.get_instructions()
-    assert instructions_provider is None
-
-
-@pytest.mark.asyncio
-async def test_skills_capability_get_instructions_handles_toolsets_importerror(monkeypatch: pytest.MonkeyPatch) -> None:
-    """get_instructions should delegate when importing pydantic_ai.toolsets fails."""
-    if not _capabilities_available():
-        pytest.skip('Capabilities API is not available in this environment')
-
-    capability = SkillsCapability(skills=[])
-
-    async def _fake_get_instructions(ctx: object) -> str:
-        _ = ctx
-        return 'delegated-on-importerror'
-
-    capability.toolset.get_instructions = _fake_get_instructions  # type: ignore[method-assign]
-
-    real_import = builtins.__import__
-
-    def _import_with_toolsets_error(name: str, *args: Any, **kwargs: Any) -> Any:
-        if name == 'pydantic_ai.toolsets':
-            raise ImportError('simulated toolsets import failure')
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, '__import__', _import_with_toolsets_error)
-
-    instructions_provider = capability.get_instructions()
-    assert callable(instructions_provider)
-    assert await instructions_provider(None) == 'delegated-on-importerror'
-
-
-def test_capability_module_import_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Module-level fallback assignments should be used when pydantic-ai imports fail."""
-    real_import = builtins.__import__
-
-    def _import_with_failures(name: str, *args: Any, **kwargs: Any) -> Any:
-        if name in {
-            'pydantic_ai.tools',
-            'pydantic_ai.agent.abstract',
-            'pydantic_ai.capabilities',
-        }:
-            raise ImportError(f'simulated import failure for {name}')
-        return real_import(name, *args, **kwargs)
-
-    with monkeypatch.context() as scoped:
-        scoped.setattr(builtins, '__import__', _import_with_failures)
-        reloaded = importlib.reload(capability_module)
-
-    assert reloaded.AgentDepsT is Any
-    assert reloaded.RunContext is Any
-    assert reloaded.AgentInstructions is Any
-    assert reloaded._CAPABILITIES_AVAILABLE is False
-
-    # Restore the module state for later tests.
-    importlib.reload(capability_module)
+    assert capability.get_instructions() is None

--- a/uv.lock
+++ b/uv.lock
@@ -737,7 +737,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2944,7 +2944,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-skills"
-version = "0.6.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -3002,7 +3002,7 @@ requires-dist = [
     { name = "mkdocs-section-index", marker = "extra == 'docs'", specifier = ">=0.3.10" },
     { name = "mkdocs-tooltips", marker = "extra == 'docs'", specifier = ">=0.1.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=1.0.0" },
-    { name = "pydantic-ai-slim", specifier = ">=0.5.0" },
+    { name = "pydantic-ai-slim", specifier = ">=1.74" },
     { name = "pydantic-ai-slim", extras = ["mcp", "openai", "logfire"], marker = "extra == 'examples'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },


### PR DESCRIPTION
## Summary

- Bump `pydantic-ai-slim` floor to `>=1.74` and delete the version-detection scaffolding it was bridging (`try/except ImportError`, `_CAPABILITIES_AVAILABLE` flag, fallback `AbstractCapability` placeholder, `hasattr`-based branching in `get_instructions`).
- Simplify `SkillsCapability.get_instructions()` to `return None` — on `>=1.74` the agent extracts instructions natively from the toolset.
- Trim the matching legacy/import-failure tests in `tests/test_capability.py` and strip every "pydantic-ai >=1.71 / <1.74" qualifier and manual instructions-hook escape hatch from the docs, `README.md`, and `AGENTS.md`.

## Why

The package previously supported `pydantic-ai-slim>=0.5.0` with three behavioral tiers (<1.71, 1.71–1.73, >=1.74). That produced runtime-import shims, dual code paths, and parallel "old vs new" docs caveats. Requiring `>=1.74` collapses everything to a single modern path.

## Jira

[DEV-1192](https://douglastrajano.atlassian.net/browse/DEV-1192)

## Test plan

- [x] `uv sync --all-extras` resolves cleanly with the new floor
- [x] `uv run pytest` — 382 passed
- [x] `uv run ruff check pydantic_ai_skills tests` — All checks passed
- [x] `grep -rn "1\.71\|1\.74\|< 1\.74"` across docs/source returns no remaining version qualifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEV-1192]: https://douglastrajano.atlassian.net/browse/DEV-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ