### PR TITLE
DEV-1193: add Skill.from_file() classmethod

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -37,7 +37,7 @@ The package uses dataclasses for type-safe skill representation:
 
 | Method | Description |
 |--------|-------------|
-| `from_file(path, validate=True, script_executor=None)` | Classmethod — load a skill from a `SKILL.md` file or its parent directory. Raises `SkillValidationError` if the file is missing or the skill is invalid. |
+| `from_file(path, validate=True, script_executor=None)` | Classmethod — load a skill from a `SKILL.md` file or its parent directory. Raises `SkillValidationError` for structural problems (wrong filename, YAML errors, missing `name` when `validate=True`). Metadata quality issues (bad name format, missing description, overlong body) emit `UserWarning` regardless of the `validate` flag. |
 | `@resource` | Decorator to attach a callable resource to the skill. |
 | `@script` | Decorator to attach a callable script to the skill. |
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -37,6 +37,7 @@ The package uses dataclasses for type-safe skill representation:
 
 | Method | Description |
 |--------|-------------|
+| `from_file(path, validate=True, script_executor=None)` | Classmethod — load a skill from a `SKILL.md` file or its parent directory. Raises `SkillValidationError` if the file is missing or the skill is invalid. |
 | `@resource` | Decorator to attach a callable resource to the skill. |
 | `@script` | Decorator to attach a callable script to the skill. |
 

--- a/docs/creating-skills.md
+++ b/docs/creating-skills.md
@@ -676,6 +676,22 @@ toolset = SkillsToolset(directories=[
 ])
 ```
 
+### Loading a Single Skill
+
+When you know the exact path to a skill, use `Skill.from_file()` instead of `SkillsDirectory`:
+
+```python
+from pydantic_ai_skills import Skill
+
+# Pass the directory that contains SKILL.md …
+skill = Skill.from_file("./skills/research/arxiv-search")
+
+# … or pass the SKILL.md file directly
+skill = Skill.from_file("./skills/research/arxiv-search/SKILL.md")
+```
+
+`from_file()` raises `SkillValidationError` if the file is missing or the `name` field is absent (when `validate=True`, the default).
+
 ## Skill Metadata
 
 Add useful metadata to help organize and discover skills:

--- a/pydantic_ai_skills/_parsing.py
+++ b/pydantic_ai_skills/_parsing.py
@@ -31,14 +31,24 @@ def parse_skill_md(content: str) -> tuple[dict[str, Any], str]:
     Raises:
         SkillValidationError: If YAML parsing fails.
     """
-    frontmatter_pattern = r'^---\s*\n(.*?)^---\s*\n'
-    match = re.search(frontmatter_pattern, content, re.DOTALL | re.MULTILINE)
+    lines = content.split('\n')
 
-    if not match:
+    # Frontmatter must open at line 0
+    if not lines or lines[0].rstrip() != '---':
         return {}, content.strip()
 
-    frontmatter_yaml = match.group(1).strip()
-    instructions = content[match.end() :].strip()
+    # Linear scan for the closing --- (no backtracking risk)
+    closing_idx: int | None = None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip() == '---':
+            closing_idx = i
+            break
+
+    if closing_idx is None:
+        return {}, content.strip()
+
+    frontmatter_yaml = '\n'.join(lines[1:closing_idx]).strip()
+    instructions = '\n'.join(lines[closing_idx + 1 :]).strip()
 
     if not frontmatter_yaml:
         return {}, instructions

--- a/pydantic_ai_skills/_parsing.py
+++ b/pydantic_ai_skills/_parsing.py
@@ -63,6 +63,35 @@ def parse_skill_md(content: str) -> tuple[dict[str, Any], str]:
     return frontmatter, instructions
 
 
+def _validate_name_format(name: str, location: str) -> bool:
+    """Validate skill name format and emit warnings. Returns False if any check fails."""
+    is_valid = True
+    if len(name) > 64:
+        warnings.warn(
+            f"Skill name '{name}'{location} exceeds 64 characters ({len(name)} chars) recommendation."
+            f' Consider shortening it.',
+            UserWarning,
+            stacklevel=3,
+        )
+        is_valid = False
+    elif not SKILL_NAME_PATTERN.match(name):
+        warnings.warn(
+            f"Skill name '{name}'{location} should contain only lowercase letters, numbers, and hyphens",
+            UserWarning,
+            stacklevel=3,
+        )
+        is_valid = False
+    for reserved in RESERVED_WORDS:
+        if reserved in name:
+            warnings.warn(
+                f"Skill name '{name}'{location} contains reserved word '{reserved}'",
+                UserWarning,
+                stacklevel=3,
+            )
+            is_valid = False
+    return is_valid
+
+
 def validate_skill_metadata(
     frontmatter: dict[str, Any],
     instructions: str,
@@ -84,9 +113,9 @@ def validate_skill_metadata(
     # Coerce to str — YAML values may be int/list/None for pathological frontmatter
     name = str(frontmatter.get('name') or '')
     description = str(frontmatter.get('description') or '')
+    compatibility = str(frontmatter.get('compatibility') or '')
     location = f' ({uri})' if uri else ''
 
-    # Warn when description is absent
     if not description:
         warnings.warn(
             f"Skill '{name}'{location}: missing recommended 'description' field",
@@ -95,34 +124,9 @@ def validate_skill_metadata(
         )
         is_valid = False
 
-    # Validate name format
-    if name:
-        if len(name) > 64:
-            warnings.warn(
-                f"Skill name '{name}'{location} exceeds 64 characters ({len(name)} chars) recommendation."
-                f' Consider shortening it.',
-                UserWarning,
-                stacklevel=2,
-            )
-            is_valid = False
-        elif not SKILL_NAME_PATTERN.match(name):
-            warnings.warn(
-                f"Skill name '{name}'{location} should contain only lowercase letters, numbers, and hyphens",
-                UserWarning,
-                stacklevel=2,
-            )
-            is_valid = False
-        # Check for reserved words
-        for reserved in RESERVED_WORDS:
-            if reserved in name:
-                warnings.warn(
-                    f"Skill name '{name}'{location} contains reserved word '{reserved}'",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                is_valid = False
+    if name and not _validate_name_format(name, location):
+        is_valid = False
 
-    # Validate description
     if description and len(description) > 1024:
         warnings.warn(
             f"Skill '{name}'{location}: description exceeds 1024 characters ({len(description)} chars)",
@@ -131,8 +135,6 @@ def validate_skill_metadata(
         )
         is_valid = False
 
-    # Validate compatibility (if provided)
-    compatibility = str(frontmatter.get('compatibility') or '')
     if compatibility and len(compatibility) > 500:
         warnings.warn(
             f"Skill '{name}'{location}: compatibility exceeds 500 characters ({len(compatibility)} chars)",
@@ -141,11 +143,9 @@ def validate_skill_metadata(
         )
         is_valid = False
 
-    # Validate instructions length (Anthropic recommends under 500 lines)
-    lines = instructions.split('\n')
-    if len(lines) > 500:
+    if len(instructions.split('\n')) > 500:
         warnings.warn(
-            f"Skill '{name}'{location}: SKILL.md body exceeds recommended 500 lines ({len(lines)} lines). "
+            f"Skill '{name}'{location}: SKILL.md body exceeds recommended 500 lines. "
             f'Consider splitting into separate resource files.',
             UserWarning,
             stacklevel=2,

--- a/pydantic_ai_skills/_parsing.py
+++ b/pydantic_ai_skills/_parsing.py
@@ -55,9 +55,12 @@ def parse_skill_md(content: str) -> tuple[dict[str, Any], str]:
 
     try:
         frontmatter = yaml.safe_load(frontmatter_yaml)
-        return frontmatter, instructions
     except yaml.YAMLError as e:
         raise SkillValidationError(f'Failed to parse YAML frontmatter: {e}') from e
+
+    if not isinstance(frontmatter, dict):
+        raise SkillValidationError(f'YAML frontmatter must be a mapping, got {type(frontmatter).__name__}')
+    return frontmatter, instructions
 
 
 def validate_skill_metadata(
@@ -78,9 +81,19 @@ def validate_skill_metadata(
         True if validation passed with no issues, False if warnings were emitted.
     """
     is_valid = True
-    name = frontmatter.get('name', '')
-    description = frontmatter.get('description', '')
+    # Coerce to str — YAML values may be int/list/None for pathological frontmatter
+    name = str(frontmatter.get('name') or '')
+    description = str(frontmatter.get('description') or '')
     location = f' ({uri})' if uri else ''
+
+    # Warn when description is absent
+    if not description:
+        warnings.warn(
+            f"Skill '{name}'{location}: missing recommended 'description' field",
+            UserWarning,
+            stacklevel=2,
+        )
+        is_valid = False
 
     # Validate name format
     if name:
@@ -119,7 +132,7 @@ def validate_skill_metadata(
         is_valid = False
 
     # Validate compatibility (if provided)
-    compatibility = frontmatter.get('compatibility', '')
+    compatibility = str(frontmatter.get('compatibility') or '')
     if compatibility and len(compatibility) > 500:
         warnings.warn(
             f"Skill '{name}'{location}: compatibility exceeds 500 characters ({len(compatibility)} chars)",

--- a/pydantic_ai_skills/_parsing.py
+++ b/pydantic_ai_skills/_parsing.py
@@ -1,0 +1,132 @@
+"""Pure parsing and validation helpers for SKILL.md files.
+
+These functions have no dependency on types.py or local.py, making them safe
+to import from types.py without creating circular imports.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from typing import Any
+
+import yaml
+
+from .exceptions import SkillValidationError
+
+# agentskills.io naming convention: lowercase letters, numbers, and hyphens only (no consecutive hyphens)
+SKILL_NAME_PATTERN = re.compile(r'^[a-z0-9]+(-[a-z0-9]+)*$')
+RESERVED_WORDS = {'anthropic', 'claude'}
+
+
+def parse_skill_md(content: str) -> tuple[dict[str, Any], str]:
+    """Parse a SKILL.md file into frontmatter and instructions.
+
+    Args:
+        content: Full content of the SKILL.md file.
+
+    Returns:
+        Tuple of (frontmatter_dict, instructions_markdown).
+
+    Raises:
+        SkillValidationError: If YAML parsing fails.
+    """
+    frontmatter_pattern = r'^---\s*\n(.*?)^---\s*\n'
+    match = re.search(frontmatter_pattern, content, re.DOTALL | re.MULTILINE)
+
+    if not match:
+        return {}, content.strip()
+
+    frontmatter_yaml = match.group(1).strip()
+    instructions = content[match.end() :].strip()
+
+    if not frontmatter_yaml:
+        return {}, instructions
+
+    try:
+        frontmatter = yaml.safe_load(frontmatter_yaml)
+        return frontmatter, instructions
+    except yaml.YAMLError as e:
+        raise SkillValidationError(f'Failed to parse YAML frontmatter: {e}') from e
+
+
+def validate_skill_metadata(
+    frontmatter: dict[str, Any],
+    instructions: str,
+    uri: str | None = None,
+) -> bool:
+    """Validate skill metadata against Anthropic's requirements.
+
+    Emits warnings for any validation issues found.
+
+    Args:
+        frontmatter: Parsed YAML frontmatter.
+        instructions: The skill instructions content.
+        uri: Optional URI or path identifying the skill source for diagnostics.
+
+    Returns:
+        True if validation passed with no issues, False if warnings were emitted.
+    """
+    is_valid = True
+    name = frontmatter.get('name', '')
+    description = frontmatter.get('description', '')
+    location = f' ({uri})' if uri else ''
+
+    # Validate name format
+    if name:
+        if len(name) > 64:
+            warnings.warn(
+                f"Skill name '{name}'{location} exceeds 64 characters ({len(name)} chars) recommendation."
+                f' Consider shortening it.',
+                UserWarning,
+                stacklevel=2,
+            )
+            is_valid = False
+        elif not SKILL_NAME_PATTERN.match(name):
+            warnings.warn(
+                f"Skill name '{name}'{location} should contain only lowercase letters, numbers, and hyphens",
+                UserWarning,
+                stacklevel=2,
+            )
+            is_valid = False
+        # Check for reserved words
+        for reserved in RESERVED_WORDS:
+            if reserved in name:
+                warnings.warn(
+                    f"Skill name '{name}'{location} contains reserved word '{reserved}'",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                is_valid = False
+
+    # Validate description
+    if description and len(description) > 1024:
+        warnings.warn(
+            f"Skill '{name}'{location}: description exceeds 1024 characters ({len(description)} chars)",
+            UserWarning,
+            stacklevel=2,
+        )
+        is_valid = False
+
+    # Validate compatibility (if provided)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility and len(compatibility) > 500:
+        warnings.warn(
+            f"Skill '{name}'{location}: compatibility exceeds 500 characters ({len(compatibility)} chars)",
+            UserWarning,
+            stacklevel=2,
+        )
+        is_valid = False
+
+    # Validate instructions length (Anthropic recommends under 500 lines)
+    lines = instructions.split('\n')
+    if len(lines) > 500:
+        warnings.warn(
+            f"Skill '{name}'{location}: SKILL.md body exceeds recommended 500 lines ({len(lines)} lines). "
+            f'Consider splitting into separate resource files.',
+            UserWarning,
+            stacklevel=2,
+        )
+        is_valid = False
+
+    return is_valid

--- a/pydantic_ai_skills/_parsing.py
+++ b/pydantic_ai_skills/_parsing.py
@@ -143,9 +143,10 @@ def validate_skill_metadata(
         )
         is_valid = False
 
-    if len(instructions.split('\n')) > 500:
+    line_count = len(instructions.split('\n'))
+    if line_count > 500:
         warnings.warn(
-            f"Skill '{name}'{location}: SKILL.md body exceeds recommended 500 lines. "
+            f"Skill '{name}'{location}: SKILL.md body exceeds recommended 500 lines ({line_count} lines). "
             f'Consider splitting into separate resource files.',
             UserWarning,
             stacklevel=2,

--- a/pydantic_ai_skills/directory.py
+++ b/pydantic_ai_skills/directory.py
@@ -10,13 +10,10 @@ internal helper functions for skill validation, metadata parsing, and resource/s
 from __future__ import annotations
 
 import os
-import re
 import warnings
 from pathlib import Path
-from typing import Any
 
-import yaml
-
+from ._parsing import parse_skill_md, validate_skill_metadata
 from .exceptions import (
     SkillNotFoundError,
     SkillValidationError,
@@ -76,123 +73,6 @@ def _resolve_script_path(script_file: Path, skill_folder_resolved: Path) -> Path
 
 
 __all__ = ['SkillsDirectory', 'discover_skills', 'parse_skill_md', 'validate_skill_metadata']
-
-# agentskills.io naming convention: lowercase letters, numbers, and hyphens only (no consecutive hyphens)
-SKILL_NAME_PATTERN = re.compile(r'^[a-z0-9]+(-[a-z0-9]+)*$')
-RESERVED_WORDS = {'anthropic', 'claude'}
-
-
-def validate_skill_metadata(
-    frontmatter: dict[str, Any],
-    instructions: str,
-    uri: str | None = None,
-) -> bool:
-    """Validate skill metadata against Anthropic's requirements.
-
-    Emits warnings for any validation issues found.
-
-    Args:
-        frontmatter: Parsed YAML frontmatter.
-        instructions: The skill instructions content.
-        uri: Optional URI or path identifying the skill source for diagnostics.
-
-    Returns:
-        True if validation passed with no issues, False if warnings were emitted.
-    """
-    is_valid = True
-    name = frontmatter.get('name', '')
-    description = frontmatter.get('description', '')
-    location = f' ({uri})' if uri else ''
-
-    # Validate name format
-    if name:
-        if len(name) > 64:
-            warnings.warn(
-                f"Skill name '{name}'{location} exceeds 64 characters ({len(name)} chars) recommendation."
-                f' Consider shortening it.',
-                UserWarning,
-                stacklevel=2,
-            )
-            is_valid = False
-        elif not SKILL_NAME_PATTERN.match(name):
-            warnings.warn(
-                f"Skill name '{name}'{location} should contain only lowercase letters, numbers, and hyphens",
-                UserWarning,
-                stacklevel=2,
-            )
-            is_valid = False
-        # Check for reserved words
-        for reserved in RESERVED_WORDS:
-            if reserved in name:
-                warnings.warn(
-                    f"Skill name '{name}'{location} contains reserved word '{reserved}'",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                is_valid = False
-
-    # Validate description
-    if description and len(description) > 1024:
-        warnings.warn(
-            f"Skill '{name}'{location}: description exceeds 1024 characters ({len(description)} chars)",
-            UserWarning,
-            stacklevel=2,
-        )
-        is_valid = False
-
-    # Validate compatibility (if provided)
-    compatibility = frontmatter.get('compatibility', '')
-    if compatibility and len(compatibility) > 500:
-        warnings.warn(
-            f"Skill '{name}'{location}: compatibility exceeds 500 characters ({len(compatibility)} chars)",
-            UserWarning,
-            stacklevel=2,
-        )
-        is_valid = False
-
-    # Validate instructions length (Anthropic recommends under 500 lines)
-    lines = instructions.split('\n')
-    if len(lines) > 500:
-        warnings.warn(
-            f"Skill '{name}'{location}: SKILL.md body exceeds recommended 500 lines ({len(lines)} lines). "
-            f'Consider splitting into separate resource files.',
-            UserWarning,
-            stacklevel=2,
-        )
-        is_valid = False
-
-    return is_valid
-
-
-def parse_skill_md(content: str) -> tuple[dict[str, Any], str]:
-    """Parse a SKILL.md file into frontmatter and instructions.
-
-    Args:
-        content: Full content of the SKILL.md file.
-
-    Returns:
-        Tuple of (frontmatter_dict, instructions_markdown).
-
-    Raises:
-        SkillValidationError: If YAML parsing fails.
-    """
-    frontmatter_pattern = r'^---\s*\n(.*?)^---\s*\n'
-    match = re.search(frontmatter_pattern, content, re.DOTALL | re.MULTILINE)
-
-    if not match:
-        return {}, content.strip()
-
-    frontmatter_yaml = match.group(1).strip()
-    instructions = content[match.end() :].strip()
-
-    if not frontmatter_yaml:
-        return {}, instructions
-
-    try:
-        frontmatter = yaml.safe_load(frontmatter_yaml)
-        return frontmatter, instructions
-    except yaml.YAMLError as e:
-        raise SkillValidationError(f'Failed to parse YAML frontmatter: {e}') from e
 
 
 def _discover_resources(skill_folder: Path) -> list[SkillResource]:
@@ -309,61 +189,6 @@ def _discover_scripts(
     return scripts
 
 
-def _load_skill_from_file(
-    skill_file: Path,
-    validate: bool,
-    script_executor: LocalSkillScriptExecutor | CallableSkillScriptExecutor,
-) -> Skill | None:
-    """Parse and build a single :class:`Skill` from a SKILL.md file.
-
-    Args:
-        skill_file: Path to the SKILL.md file.
-        validate: Whether to validate skill structure.
-        script_executor: Executor used for file-based scripts.
-
-    Returns:
-        A :class:`Skill` instance, or ``None`` if the skill should be skipped.
-
-    Raises:
-        SkillValidationError: When validation fails and *validate* is ``True``.
-    """
-    skill_folder = skill_file.parent
-    content = skill_file.read_text(encoding='utf-8')
-    frontmatter, instructions = parse_skill_md(content)
-
-    name = frontmatter.get('name')
-    description = frontmatter.get('description', '')
-
-    if not name:
-        if validate:
-            warnings.warn(f'Skipping skill at {skill_file}: missing required "name" field.', UserWarning, stacklevel=3)
-            return None
-        else:
-            name = skill_folder.name
-
-    license_field = frontmatter.get('license')
-    compatibility_field = frontmatter.get('compatibility')
-    metadata = {k: v for k, v in frontmatter.items() if k not in ('name', 'description', 'license', 'compatibility')}
-
-    if validate:
-        validate_skill_metadata(frontmatter, instructions, uri=str(skill_folder.resolve()))
-
-    resources = _discover_resources(skill_folder)
-    scripts = _discover_scripts(skill_folder, name, script_executor)
-
-    return Skill(
-        name=name,
-        description=description,
-        content=instructions,
-        license=license_field,
-        compatibility=compatibility_field,
-        uri=str(skill_folder.resolve()),
-        resources=resources,
-        scripts=scripts,
-        metadata=metadata if metadata else None,
-    )
-
-
 def discover_skills(
     path: str | Path,
     validate: bool = True,
@@ -401,9 +226,8 @@ def discover_skills(
     skill_files = _find_skill_files(dir_path, max_depth)
     for skill_file in skill_files:
         try:
-            skill = _load_skill_from_file(skill_file, validate, executor)
-            if skill is not None:
-                skills.append(skill)
+            skill = Skill.from_file(skill_file, validate=validate, script_executor=executor)
+            skills.append(skill)
         except SkillValidationError as sve:
             if validate:
                 raise

--- a/pydantic_ai_skills/types.py
+++ b/pydantic_ai_skills/types.py
@@ -272,16 +272,23 @@ class Skill:
 
         Args:
             path: Path to a ``SKILL.md`` file or to the directory that contains one.
-            validate: Whether to validate skill structure (name, description, etc.).
+                When a file path is given it must be named exactly ``SKILL.md``.
+            validate: When ``True`` (default), raises :exc:`SkillValidationError` for
+                structural problems (missing ``SKILL.md``, YAML errors, absent ``name``
+                field).  Metadata quality issues (bad name format, missing description,
+                overlong body) emit :class:`UserWarning` regardless of this flag.
             script_executor: Optional custom script executor for file-based scripts.
 
         Returns:
             A :class:`Skill` instance.
 
         Raises:
-            SkillValidationError: If the path does not contain a valid SKILL.md or
-                validation fails.
-            OSError: If the file cannot be read (permissions, I/O error, etc.).
+            SkillValidationError: For structural problems: wrong filename, missing
+                ``SKILL.md``, invalid YAML frontmatter, or (when *validate* is
+                ``True``) a missing ``name`` field.
+            OSError: Propagated directly for unreadable files, permission errors, or
+                I/O failures.  :func:`discover_skills` catches this and re-raises it
+                as :exc:`SkillValidationError`, so direct callers should handle both.
         """
         from .directory import _discover_resources, _discover_scripts  # lazy: transitive circular via local.py
         from .local import LocalSkillScriptExecutor as _LocalExecutor
@@ -290,7 +297,7 @@ class Skill:
         if skill_path.is_dir():
             skill_file = skill_path / 'SKILL.md'
         else:
-            if skill_path.name.upper() != 'SKILL.MD':
+            if skill_path.name != 'SKILL.md':
                 raise SkillValidationError(f"Expected a SKILL.md file or its parent directory, got '{skill_path.name}'")
             skill_file = skill_path
 
@@ -301,12 +308,14 @@ class Skill:
         raw = skill_file.read_text(encoding='utf-8')
         frontmatter, instructions = parse_skill_md(raw)
 
-        name = frontmatter.get('name')
+        # Coerce before the empty check so YAML scalars like `name: 0` load as '0'
+        # rather than being treated as missing.  Only None/empty-string falls back.
+        raw_name = frontmatter.get('name')
+        name = str(raw_name) if raw_name is not None else ''
         if not name:
             if validate:
                 raise SkillValidationError(f'Skill at {skill_file} is missing the required "name" field')
             name = skill_folder.name
-        name = str(name)  # coerce int/float YAML values to str
 
         # Coerce YAML scalar fields to str — YAML may return int/float/None
         description = str(frontmatter.get('description') or '')

--- a/pydantic_ai_skills/types.py
+++ b/pydantic_ai_skills/types.py
@@ -12,19 +12,20 @@ Data classes:
 
 from __future__ import annotations
 
-import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, Generic, TypeVar
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic.json_schema import GenerateJsonSchema
 from pydantic_ai import _function_schema
 from pydantic_ai.tools import GenerateToolJsonSchema
 
+from ._parsing import SKILL_NAME_PATTERN, parse_skill_md, validate_skill_metadata
 from .exceptions import SkillValidationError
 
-# Skill name pattern: lowercase letters, numbers, and hyphens (no consecutive hyphens)
-SKILL_NAME_PATTERN = re.compile(r'^[a-z0-9]+(-[a-z0-9]+)*$')
+if TYPE_CHECKING:
+    from .local import CallableSkillScriptExecutor, LocalSkillScriptExecutor
 
 # Generic type variable for dependencies
 DepsT = TypeVar('DepsT')
@@ -259,6 +260,72 @@ class Skill:
         """
         if self.uri is None:
             self.uri = f'skill://{self.name}'
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        validate: bool = True,
+        script_executor: LocalSkillScriptExecutor | CallableSkillScriptExecutor | None = None,
+    ) -> Skill:
+        """Load a :class:`Skill` from a SKILL.md file or its parent directory.
+
+        Args:
+            path: Path to a ``SKILL.md`` file or to the directory that contains one.
+            validate: Whether to validate skill structure (name, description, etc.).
+            script_executor: Optional custom script executor for file-based scripts.
+
+        Returns:
+            A :class:`Skill` instance.
+
+        Raises:
+            SkillValidationError: If the path does not contain a valid SKILL.md or
+                validation fails.
+        """
+        from .directory import _discover_resources, _discover_scripts  # lazy: transitive circular via local.py
+        from .local import LocalSkillScriptExecutor as _LocalExecutor
+
+        skill_path = Path(path).expanduser().resolve()
+        skill_file = skill_path / 'SKILL.md' if skill_path.is_dir() else skill_path
+
+        if not skill_file.exists():
+            raise SkillValidationError(f'SKILL.md not found at {skill_file}')
+
+        skill_folder = skill_file.parent
+        raw = skill_file.read_text(encoding='utf-8')
+        frontmatter, instructions = parse_skill_md(raw)
+
+        name = frontmatter.get('name')
+        if not name:
+            if validate:
+                raise SkillValidationError(f'Skill at {skill_file} is missing the required "name" field')
+            name = skill_folder.name
+
+        description = frontmatter.get('description', '')
+        license_field = frontmatter.get('license')
+        compatibility_field = frontmatter.get('compatibility')
+        metadata = {
+            k: v for k, v in frontmatter.items() if k not in ('name', 'description', 'license', 'compatibility')
+        }
+
+        if validate:
+            validate_skill_metadata(frontmatter, instructions, uri=str(skill_folder))
+
+        executor = script_executor or _LocalExecutor()
+        resources = _discover_resources(skill_folder)
+        scripts = _discover_scripts(skill_folder, name, executor)
+
+        return cls(
+            name=name,
+            description=description,
+            content=instructions,
+            license=license_field,
+            compatibility=compatibility_field,
+            uri=str(skill_folder),
+            resources=resources,
+            scripts=scripts,
+            metadata=metadata if metadata else None,
+        )
 
     def resource(
         self,

--- a/pydantic_ai_skills/types.py
+++ b/pydantic_ai_skills/types.py
@@ -281,12 +281,18 @@ class Skill:
         Raises:
             SkillValidationError: If the path does not contain a valid SKILL.md or
                 validation fails.
+            OSError: If the file cannot be read (permissions, I/O error, etc.).
         """
         from .directory import _discover_resources, _discover_scripts  # lazy: transitive circular via local.py
         from .local import LocalSkillScriptExecutor as _LocalExecutor
 
         skill_path = Path(path).expanduser().resolve()
-        skill_file = skill_path / 'SKILL.md' if skill_path.is_dir() else skill_path
+        if skill_path.is_dir():
+            skill_file = skill_path / 'SKILL.md'
+        else:
+            if skill_path.name.upper() != 'SKILL.MD':
+                raise SkillValidationError(f"Expected a SKILL.md file or its parent directory, got '{skill_path.name}'")
+            skill_file = skill_path
 
         if not skill_file.exists():
             raise SkillValidationError(f'SKILL.md not found at {skill_file}')
@@ -300,10 +306,14 @@ class Skill:
             if validate:
                 raise SkillValidationError(f'Skill at {skill_file} is missing the required "name" field')
             name = skill_folder.name
+        name = str(name)  # coerce int/float YAML values to str
 
-        description = frontmatter.get('description', '')
+        # Coerce YAML scalar fields to str — YAML may return int/float/None
+        description = str(frontmatter.get('description') or '')
         license_field = frontmatter.get('license')
+        license_field = str(license_field) if license_field is not None else None
         compatibility_field = frontmatter.get('compatibility')
+        compatibility_field = str(compatibility_field) if compatibility_field is not None else None
         metadata = {
             k: v for k, v in frontmatter.items() if k not in ('name', 'description', 'license', 'compatibility')
         }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from pydantic_ai_skills.directory import discover_skills
+from pydantic_ai_skills.directory import SkillsDirectory, discover_skills
 from pydantic_ai_skills.exceptions import SkillValidationError
 
 
@@ -282,3 +282,26 @@ Content.
     assert 'resources/schema.json' in resource_names
     assert 'resources/template.txt' in resource_names
     assert 'resources/nested/data.csv' in resource_names
+
+
+def test_skills_directory_missing_name_with_validation(tmp_path: Path) -> None:
+    """SkillsDirectory with validate=True raises on a skill missing its name."""
+    skill_dir = tmp_path / 'nameless'
+    skill_dir.mkdir()
+    (skill_dir / 'SKILL.md').write_text('---\ndescription: No name\n---\n\nContent.\n')
+
+    with pytest.raises(SkillValidationError, match='missing the required "name" field'):
+        SkillsDirectory(path=tmp_path, validate=True)
+
+
+def test_skills_directory_missing_name_without_validation(tmp_path: Path) -> None:
+    """SkillsDirectory with validate=False falls back to the directory name."""
+    skill_dir = tmp_path / 'my-skill'
+    skill_dir.mkdir()
+    (skill_dir / 'SKILL.md').write_text('---\ndescription: No name\n---\n\nContent.\n')
+
+    sd = SkillsDirectory(path=tmp_path, validate=False)
+    skills = list(sd.get_skills().values())
+
+    assert len(skills) == 1
+    assert skills[0].name == 'my-skill'

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from pydantic_ai_skills.directory import discover_skills
+from pydantic_ai_skills.exceptions import SkillValidationError
 
 
 def test_discover_skills_single_skill(tmp_path: Path) -> None:
@@ -217,9 +218,9 @@ description: Missing name field
 Content.
 """)
 
-    # With validation, should skip this skill (log warning)
-    skills = discover_skills(tmp_path, validate=True)
-    assert len(skills) == 0
+    # With validation, missing name is an error
+    with pytest.raises(SkillValidationError, match='missing the required "name" field'):
+        discover_skills(tmp_path, validate=True)
 
 
 def test_discover_skills_missing_name_without_validation(tmp_path: Path) -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -104,9 +104,9 @@ def test_from_file_explicit_skill_md_path(tmp_path: Path) -> None:
 
 
 def test_from_file_missing_skill_md(tmp_path: Path) -> None:
-    """A path without SKILL.md raises SkillValidationError."""
+    """A SKILL.md path that does not exist raises SkillValidationError."""
     with pytest.raises(SkillValidationError, match='SKILL.md not found'):
-        Skill.from_file(tmp_path / 'nonexistent')
+        Skill.from_file(tmp_path / 'nonexistent' / 'SKILL.md')
 
 
 def test_from_file_missing_name_validate_true(tmp_path: Path) -> None:
@@ -138,3 +138,54 @@ def test_from_file_with_resources(tmp_path: Path) -> None:
 
     assert len(skill.resources) == 1
     assert skill.resources[0].name == 'schema.json'
+
+
+def test_from_file_wrong_filename_raises(tmp_path: Path) -> None:
+    """Passing a file that is not named SKILL.md raises SkillValidationError."""
+    other_file = tmp_path / 'README.md'
+    other_file.write_text('# not a skill')
+
+    with pytest.raises(SkillValidationError, match='SKILL.md'):
+        Skill.from_file(other_file)
+
+
+def test_from_file_non_dict_frontmatter_raises(tmp_path: Path) -> None:
+    """YAML frontmatter that is a list (not a mapping) raises SkillValidationError."""
+    skill_dir = tmp_path / 'bad-skill'
+    _write_skill_md(skill_dir, '---\n- item1\n- item2\n---\n\nContent.\n')
+
+    with pytest.raises(SkillValidationError, match='mapping'):
+        Skill.from_file(skill_dir, validate=False)
+
+
+def test_from_file_custom_script_executor(tmp_path: Path) -> None:
+    """A custom script_executor is passed through to script discovery."""
+    import sys
+
+    from pydantic_ai_skills.local import LocalSkillScriptExecutor
+
+    skill_dir = tmp_path / 'my-skill'
+    _write_skill_md(skill_dir, '---\nname: my-skill\ndescription: A skill\n---\n\nInstructions.\n')
+
+    scripts_dir = skill_dir / 'scripts'
+    scripts_dir.mkdir()
+    script = scripts_dir / 'run.py'
+    script.write_text('#!/usr/bin/env python3\nprint("hello")\n')
+    if sys.platform != 'win32':
+        script.chmod(0o755)
+
+    executor = LocalSkillScriptExecutor(timeout=120)
+    skill = Skill.from_file(skill_dir, script_executor=executor)
+
+    assert len(skill.scripts) == 1
+    assert skill.scripts[0].name == 'scripts/run.py'
+
+
+def test_from_file_integer_name_field(tmp_path: Path) -> None:
+    """A numeric name in YAML (e.g. name: 123) is coerced to str, not TypeError."""
+    skill_dir = tmp_path / 'numeric-name'
+    _write_skill_md(skill_dir, '---\nname: 123\ndescription: A skill\n---\n\nContent.\n')
+
+    skill = Skill.from_file(skill_dir, validate=False)
+
+    assert skill.name == '123'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -159,10 +159,10 @@ def test_from_file_non_dict_frontmatter_raises(tmp_path: Path) -> None:
 
 
 def test_from_file_custom_script_executor(tmp_path: Path) -> None:
-    """A custom script_executor is passed through to script discovery."""
+    """The supplied script_executor is wired into every discovered script."""
     import sys
 
-    from pydantic_ai_skills.local import LocalSkillScriptExecutor
+    from pydantic_ai_skills.local import FileBasedSkillScript, LocalSkillScriptExecutor
 
     skill_dir = tmp_path / 'my-skill'
     _write_skill_md(skill_dir, '---\nname: my-skill\ndescription: A skill\n---\n\nInstructions.\n')
@@ -179,6 +179,9 @@ def test_from_file_custom_script_executor(tmp_path: Path) -> None:
 
     assert len(skill.scripts) == 1
     assert skill.scripts[0].name == 'scripts/run.py'
+    # Verify the supplied executor is actually stored on the script object
+    assert isinstance(skill.scripts[0], FileBasedSkillScript)
+    assert skill.scripts[0].executor is executor
 
 
 def test_from_file_integer_name_field(tmp_path: Path) -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 
+import pytest
+
+from pydantic_ai_skills.exceptions import SkillValidationError
 from pydantic_ai_skills.types import Skill, SkillResource, SkillScript
 
 
@@ -70,3 +73,68 @@ def test_skill_explicit_uri_preserved() -> None:
     skill = Skill(name='my-skill', description='A skill', content='Instructions', uri='custom://my-uri')
 
     assert skill.uri == 'custom://my-uri'
+
+
+def _write_skill_md(directory: Path, content: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / 'SKILL.md').write_text(content)
+
+
+def test_from_file_directory_path(tmp_path: Path) -> None:
+    """Load a skill by passing the directory that contains SKILL.md."""
+    skill_dir = tmp_path / 'my-skill'
+    _write_skill_md(skill_dir, '---\nname: my-skill\ndescription: A skill\n---\n\nInstructions.\n')
+
+    skill = Skill.from_file(skill_dir)
+
+    assert skill.name == 'my-skill'
+    assert skill.description == 'A skill'
+    assert 'Instructions' in skill.content
+    assert skill.uri == str(skill_dir.resolve())
+
+
+def test_from_file_explicit_skill_md_path(tmp_path: Path) -> None:
+    """Load a skill by passing the SKILL.md file path directly."""
+    skill_dir = tmp_path / 'my-skill'
+    _write_skill_md(skill_dir, '---\nname: my-skill\ndescription: A skill\n---\n\nInstructions.\n')
+
+    skill = Skill.from_file(skill_dir / 'SKILL.md')
+
+    assert skill.name == 'my-skill'
+
+
+def test_from_file_missing_skill_md(tmp_path: Path) -> None:
+    """A path without SKILL.md raises SkillValidationError."""
+    with pytest.raises(SkillValidationError, match='SKILL.md not found'):
+        Skill.from_file(tmp_path / 'nonexistent')
+
+
+def test_from_file_missing_name_validate_true(tmp_path: Path) -> None:
+    """Missing name with validate=True raises SkillValidationError."""
+    skill_dir = tmp_path / 'no-name'
+    _write_skill_md(skill_dir, '---\ndescription: No name\n---\n\nContent.\n')
+
+    with pytest.raises(SkillValidationError, match='missing the required "name" field'):
+        Skill.from_file(skill_dir, validate=True)
+
+
+def test_from_file_missing_name_validate_false(tmp_path: Path) -> None:
+    """Missing name with validate=False falls back to the directory name."""
+    skill_dir = tmp_path / 'my-fallback-skill'
+    _write_skill_md(skill_dir, '---\ndescription: No name\n---\n\nContent.\n')
+
+    skill = Skill.from_file(skill_dir, validate=False)
+
+    assert skill.name == 'my-fallback-skill'
+
+
+def test_from_file_with_resources(tmp_path: Path) -> None:
+    """Resource files alongside SKILL.md are discovered and populated."""
+    skill_dir = tmp_path / 'my-skill'
+    _write_skill_md(skill_dir, '---\nname: my-skill\ndescription: A skill\n---\n\nInstructions.\n')
+    (skill_dir / 'schema.json').write_text('{"table": "users"}')
+
+    skill = Skill.from_file(skill_dir)
+
+    assert len(skill.resources) == 1
+    assert skill.resources[0].name == 'schema.json'


### PR DESCRIPTION
## Summary

- Adds `Skill.from_file(path, validate=True, script_executor=None)` classmethod — accepts a directory containing `SKILL.md` or a direct path to the file, returns a fully populated `Skill` instance including discovered resources and scripts.
- Extracts `parse_skill_md`, `validate_skill_metadata`, `SKILL_NAME_PATTERN`, and `RESERVED_WORDS` into a new `_parsing.py` module to break the `types → directory → local → types` circular-import chain, allowing `types.py` to import the pure helpers at module level.
- Removes the private `_load_skill_from_file()` from `directory.py`; `discover_skills()` now delegates to `Skill.from_file()`.

## What changed

| File | Change |
|---|---|
| `pydantic_ai_skills/_parsing.py` | **New** — pure parsing/validation helpers (zero deps on `types`/`local`) |
| `pydantic_ai_skills/types.py` | Added `Skill.from_file()`; imports `SKILL_NAME_PATTERN` and parsing helpers from `_parsing` |
| `pydantic_ai_skills/directory.py` | Removed `_load_skill_from_file()`, `parse_skill_md`, `validate_skill_metadata` definitions; imports from `_parsing`; `discover_skills` uses `Skill.from_file()` |
| `tests/test_types.py` | 6 new tests for `Skill.from_file()` |
| `tests/test_discovery.py` | Updated `test_discover_skills_missing_name_with_validation` — missing name with `validate=True` now raises `SkillValidationError` instead of silently skipping |

## Behavioral note for reviewers

Previously, `discover_skills(validate=True)` on a skill with a missing `name` field issued a `UserWarning` and skipped it (via a `None` sentinel return). Now it raises `SkillValidationError`, which is consistent with every other validation failure. The test has been updated accordingly.

## Test plan

- [x] `uv run pytest tests/test_types.py` — all 12 tests pass (6 new `from_file` tests)
- [x] `uv run pytest tests/test_discovery.py` — all 12 discovery tests pass
- [x] `uv run pytest tests/` — full suite: 388 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)