### PR TITLE
feat: coerce JSON string args to dict in run_skill_script

### DIFF
--- a/pydantic_ai_skills/toolset.py
+++ b/pydantic_ai_skills/toolset.py
@@ -74,12 +74,15 @@ LOAD_SKILL_TEMPLATE = """<skill>
 """
 
 
-def _coerce_to_dict(v: Any) -> dict[str, Any] | None:
-    """Convert JSON string to dict if needed, pass through dict/None unchanged."""
-    if isinstance(v, dict) or v is None:
-        return v
+def _coerce_to_dict(v: Any) -> Any:
+    """Convert JSON string to dict if needed, pass through non-string values unchanged."""
     if isinstance(v, str):
-        parsed = json.loads(v)
+        try:
+            parsed = json.loads(v)
+        except json.JSONDecodeError as e:
+            # 捕获 JSON 解析错误，抛出更直观的错误信息
+            raise ValueError(
+                f"Invalid JSON string. Error: {e.msg} at line {e.lineno} col {e.colno}. Input snippet: {v[:100]}")
         if not isinstance(parsed, dict):
             raise ValueError(f'args must be a JSON object, got {type(parsed).__name__}')
         return parsed

--- a/pydantic_ai_skills/toolset.py
+++ b/pydantic_ai_skills/toolset.py
@@ -82,7 +82,8 @@ def _coerce_to_dict(v: Any) -> Any:
         except json.JSONDecodeError as e:
             # Catch JSON parsing errors and throw a more intuitive error message
             raise ValueError(
-                f"Invalid JSON string. Error: {e.msg} at line {e.lineno} col {e.colno}. Input snippet: {v[:100]}")
+                f'Invalid JSON string. Error: {e.msg} at line {e.lineno} col {e.colno}. Input snippet: {v[:100]}'
+            )
         if not isinstance(parsed, dict):
             raise ValueError(f'args must be a JSON object, got {type(parsed).__name__}')
         return parsed

--- a/pydantic_ai_skills/toolset.py
+++ b/pydantic_ai_skills/toolset.py
@@ -83,7 +83,7 @@ def _coerce_to_dict(v: Any) -> Any:
             # Catch JSON parsing errors and throw a more intuitive error message
             raise ValueError(
                 f'Invalid JSON string. Error: {e.msg} at line {e.lineno} col {e.colno}. Input snippet: {v[:100]}'
-            )
+            ) from e
         if not isinstance(parsed, dict):
             raise ValueError(f'args must be a JSON object, got {type(parsed).__name__}')
         return parsed

--- a/pydantic_ai_skills/toolset.py
+++ b/pydantic_ai_skills/toolset.py
@@ -17,8 +17,9 @@ import warnings
 from collections.abc import Callable
 from inspect import signature as get_signature
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
+from pydantic import BeforeValidator
 from pydantic_ai import ModelRetry
 from pydantic_ai._griffe import doc_descriptions
 from pydantic_ai._run_context import RunContext
@@ -71,6 +72,18 @@ LOAD_SKILL_TEMPLATE = """<skill>
 </instructions>
 </skill>
 """
+
+
+def _coerce_to_dict(v: Any) -> dict[str, Any] | None:
+    """Convert JSON string to dict if needed, pass through dict/None unchanged."""
+    if isinstance(v, dict) or v is None:
+        return v
+    if isinstance(v, str):
+        parsed = json.loads(v)
+        if not isinstance(parsed, dict):
+            raise ValueError(f'args must be a JSON object, got {type(parsed).__name__}')
+        return parsed
+    return v
 
 
 class SkillsToolset(FunctionToolset[Any]):
@@ -631,7 +644,7 @@ class SkillsToolset(FunctionToolset[Any]):
             ctx: RunContext[Any],
             skill_name: str,
             script_name: str,
-            args: dict[str, Any] | None = None,
+            args: Annotated[dict[str, Any] | None, BeforeValidator(_coerce_to_dict)] = None,
         ) -> str:
             """Execute a skill script that performs actions or computations.
 

--- a/pydantic_ai_skills/toolset.py
+++ b/pydantic_ai_skills/toolset.py
@@ -80,7 +80,7 @@ def _coerce_to_dict(v: Any) -> Any:
         try:
             parsed = json.loads(v)
         except json.JSONDecodeError as e:
-            # 捕获 JSON 解析错误，抛出更直观的错误信息
+            # Catch JSON parsing errors and throw a more intuitive error message
             raise ValueError(
                 f"Invalid JSON string. Error: {e.msg} at line {e.lineno} col {e.colno}. Input snippet: {v[:100]}")
         if not isinstance(parsed, dict):

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -659,3 +659,38 @@ def test_max_retries_propagates_to_each_tool(sample_skills_dir: Path) -> None:
     assert toolset.max_retries == 3
     for name in ('list_skills', 'load_skill', 'read_skill_resource', 'run_skill_script'):
         assert toolset.tools[name].max_retries == 3, name
+
+
+# ============================================================================
+# JSON string args compatibility — _coerce_to_dict helper
+# ============================================================================
+
+
+def test_coerce_to_dict_parses_json_string() -> None:
+    """_coerce_to_dict should parse a valid JSON string to dict."""
+    from pydantic_ai_skills.toolset import _coerce_to_dict
+
+    assert _coerce_to_dict('{"key": "value"}') == {'key': 'value'}
+
+
+def test_coerce_to_dict_passes_dict_through() -> None:
+    """_coerce_to_dict should return dict unchanged."""
+    from pydantic_ai_skills.toolset import _coerce_to_dict
+
+    d = {'key': 'value'}
+    assert _coerce_to_dict(d) is d
+
+
+def test_coerce_to_dict_passes_none_through() -> None:
+    """_coerce_to_dict should return None unchanged."""
+    from pydantic_ai_skills.toolset import _coerce_to_dict
+
+    assert _coerce_to_dict(None) is None
+
+
+def test_coerce_to_dict_raises_non_object() -> None:
+    """_coerce_to_dict should raise ValueError for non-object JSON."""
+    from pydantic_ai_skills.toolset import _coerce_to_dict
+
+    with pytest.raises(ValueError, match='must be a JSON object'):
+        _coerce_to_dict('[1, 2, 3]')

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -705,11 +705,13 @@ def test_run_skill_script_coerces_json_string_args(sample_skills_dir: Path) -> N
 
     # JSON string args are coerced to dict
     args_json = json.dumps({'key': 'value'})
-    result = validator.validate_python({
-        'skill_name': 'skill-three',
-        'script_name': 'scripts/hello.py',
-        'args': args_json,
-    })
+    result = validator.validate_python(
+        {
+            'skill_name': 'skill-three',
+            'script_name': 'scripts/hello.py',
+            'args': args_json,
+        }
+    )
     assert result['args'] == {'key': 'value'}
     assert isinstance(result['args'], dict)
 
@@ -720,11 +722,13 @@ def test_run_skill_script_dict_args_pass_through(sample_skills_dir: Path) -> Non
     validator = toolset.tools['run_skill_script'].function_schema.validator
 
     args_dict = {'key': 'value'}
-    result = validator.validate_python({
-        'skill_name': 'skill-three',
-        'script_name': 'scripts/hello.py',
-        'args': args_dict,
-    })
+    result = validator.validate_python(
+        {
+            'skill_name': 'skill-three',
+            'script_name': 'scripts/hello.py',
+            'args': args_dict,
+        }
+    )
     assert result['args'] == args_dict
 
 
@@ -733,11 +737,13 @@ def test_run_skill_script_none_args_allowed(sample_skills_dir: Path) -> None:
     toolset = SkillsToolset(directories=[sample_skills_dir])
     validator = toolset.tools['run_skill_script'].function_schema.validator
 
-    result = validator.validate_python({
-        'skill_name': 'skill-three',
-        'script_name': 'scripts/hello.py',
-        'args': None,
-    })
+    result = validator.validate_python(
+        {
+            'skill_name': 'skill-three',
+            'script_name': 'scripts/hello.py',
+            'args': None,
+        }
+    )
     assert result['args'] is None
 
 
@@ -749,8 +755,10 @@ def test_run_skill_script_rejects_non_object_json(sample_skills_dir: Path) -> No
     validator = toolset.tools['run_skill_script'].function_schema.validator
 
     with pytest.raises(ValidationError, match='must be a JSON object'):
-        validator.validate_python({
-            'skill_name': 'skill-three',
-            'script_name': 'scripts/hello.py',
-            'args': '[1, 2, 3]',
-        })
+        validator.validate_python(
+            {
+                'skill_name': 'skill-three',
+                'script_name': 'scripts/hello.py',
+                'args': '[1, 2, 3]',
+            }
+        )

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -694,3 +694,63 @@ def test_coerce_to_dict_raises_non_object() -> None:
 
     with pytest.raises(ValueError, match='must be a JSON object'):
         _coerce_to_dict('[1, 2, 3]')
+
+
+def test_run_skill_script_coerces_json_string_args(sample_skills_dir: Path) -> None:
+    """Pydantic tool arg validation should coerce JSON string args into dict."""
+    import json
+
+    toolset = SkillsToolset(directories=[sample_skills_dir])
+    validator = toolset.tools['run_skill_script'].function_schema.validator
+
+    # JSON string args are coerced to dict
+    args_json = json.dumps({'key': 'value'})
+    result = validator.validate_python({
+        'skill_name': 'skill-three',
+        'script_name': 'scripts/hello.py',
+        'args': args_json,
+    })
+    assert result['args'] == {'key': 'value'}
+    assert isinstance(result['args'], dict)
+
+
+def test_run_skill_script_dict_args_pass_through(sample_skills_dir: Path) -> None:
+    """Dict args should pass through unchanged during validation."""
+    toolset = SkillsToolset(directories=[sample_skills_dir])
+    validator = toolset.tools['run_skill_script'].function_schema.validator
+
+    args_dict = {'key': 'value'}
+    result = validator.validate_python({
+        'skill_name': 'skill-three',
+        'script_name': 'scripts/hello.py',
+        'args': args_dict,
+    })
+    assert result['args'] == args_dict
+
+
+def test_run_skill_script_none_args_allowed(sample_skills_dir: Path) -> None:
+    """None args should be accepted during validation."""
+    toolset = SkillsToolset(directories=[sample_skills_dir])
+    validator = toolset.tools['run_skill_script'].function_schema.validator
+
+    result = validator.validate_python({
+        'skill_name': 'skill-three',
+        'script_name': 'scripts/hello.py',
+        'args': None,
+    })
+    assert result['args'] is None
+
+
+def test_run_skill_script_rejects_non_object_json(sample_skills_dir: Path) -> None:
+    """Non-object JSON strings (e.g. arrays) should be rejected during validation."""
+    from pydantic import ValidationError
+
+    toolset = SkillsToolset(directories=[sample_skills_dir])
+    validator = toolset.tools['run_skill_script'].function_schema.validator
+
+    with pytest.raises(ValidationError, match='must be a JSON object'):
+        validator.validate_python({
+            'skill_name': 'skill-three',
+            'script_name': 'scripts/hello.py',
+            'args': '[1, 2, 3]',
+        })

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -696,6 +696,14 @@ def test_coerce_to_dict_raises_non_object() -> None:
         _coerce_to_dict('[1, 2, 3]')
 
 
+def test_coerce_to_dict_raises_invalid_json() -> None:
+    """_coerce_to_dict should raise a specific ValueError format when JSON parsing fails."""
+    from pydantic_ai_skills.toolset import _coerce_to_dict
+
+    with pytest.raises(ValueError, match=r'Invalid JSON string\. Error: .* at line 1 col \d+\.'):
+        _coerce_to_dict('{"key": "value", }')
+
+
 def test_run_skill_script_coerces_json_string_args(sample_skills_dir: Path) -> None:
     """Pydantic tool arg validation should coerce JSON string args into dict."""
     import json


### PR DESCRIPTION
LLMs sometimes return nested dict args as JSON strings instead of objects. Add `_coerce_to_dict` helper using `Annotated[..., BeforeValidator(...)]` on the `args` parameter to automatically parse strings to dicts at validation time.