### PR TITLE
feat: add S3SkillsRegistry for S3 and S3-compatible storage

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -16,6 +16,18 @@ jobs:
       github.event.workflow_run.conclusion == 'success' ||
       github.event.workflow_run.conclusion == 'failure'
     steps:
+      # Check out the exact commit that was tested first. For fork PRs,
+      # head_repository is the fork so this correctly checks out the
+      # contributor's code. Checking out before downloading artifacts is
+      # important: actions/checkout runs `git clean -ffdx`, which would delete
+      # any artifacts (e.g. coverage.xml) downloaded into the workspace first.
+      - name: Checkout code at tested SHA
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:
@@ -41,19 +53,6 @@ jobs:
           echo "pr_head_sha=${PR_HEAD_SHA}" >> $GITHUB_OUTPUT
           echo "pr_base_ref=${PR_BASE_REF}" >> $GITHUB_OUTPUT
           echo "pr_head_ref=${PR_HEAD_REF}" >> $GITHUB_OUTPUT
-
-      # Check out the exact commit that was tested. For fork PRs, head_repository
-      # is the fork so this correctly checks out the contributor's code.
-      - name: Checkout code at tested SHA
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0
-
-      # Artifacts are downloaded to the workspace root; move coverage into the repo.
-      - name: Place coverage report
-        run: mv ../coverage.xml coverage.xml 2>/dev/null || true
 
       - name: SonarCloud Scan (PR)
         if: steps.pr_meta.outputs.pr_number != ''

--- a/docs/api/registries.md
+++ b/docs/api/registries.md
@@ -30,6 +30,13 @@
 
 ---
 
+::: pydantic_ai_skills.registries.s3.S3SkillsRegistry
+    options:
+        show_source: true
+        heading_level: 2
+
+---
+
 ## Composition Wrappers
 
 ::: pydantic_ai_skills.registries.wrapper.WrapperRegistry

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -10,6 +10,12 @@ Git-backed registries require [GitPython](https://gitpython.readthedocs.io/):
 pip install pydantic-ai-skills[git]
 ```
 
+S3-backed registries require [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html):
+
+```bash
+pip install pydantic-ai-skills[s3]
+```
+
 ## Quick Start
 
 ### Load Skills from a Git Repository
@@ -138,6 +144,88 @@ print(skill.metadata)
 #     'registry': 'GitSkillsRegistry',
 #     'repo': 'https://github.com/anthropics/skills',
 #     'version': 'abc123...',  # HEAD commit SHA
+# }
+```
+
+## S3SkillsRegistry
+
+`S3SkillsRegistry` downloads skills from an Amazon S3 bucket — or any S3-compatible store such as MinIO, Ceph, or Cloudflare R2 — into a local cache, then discovers `SKILL.md` files the same way the Git registry does.
+
+Install the optional dependency:
+
+```bash
+pip install pydantic-ai-skills[s3]
+```
+
+All connection details (credentials, `endpoint_url`, region, TLS, path-style addressing) live on the **boto3 client** you supply via `boto3_client`. When omitted, a default `boto3.client("s3")` is built, which uses boto3's standard credential resolution chain (environment variables, `~/.aws/credentials`, IAM roles, etc.).
+
+### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `bucket` | `str` | *required* | Name of the S3 bucket containing the skills. |
+| `prefix` | `str` | `""` | Key prefix inside the bucket where skill directories live. |
+| `target_dir` | `str \| Path \| None` | `None` | Local cache directory. A temp directory is used when `None`. |
+| `boto3_client` | `Any \| None` | `None` | Pre-built boto3 S3 client. A default client is created when `None`. |
+| `validate` | `bool` | `True` | Validate every discovered `SKILL.md` after syncing. |
+| `auto_install` | `bool` | `True` | Sync on construction (and on `search`/`get`). Set `False` for offline use. |
+
+### Amazon S3 (Default Client)
+
+```python
+from pydantic_ai_skills.registries import S3SkillsRegistry
+
+# Uses the ambient AWS credential chain.
+registry = S3SkillsRegistry(bucket="my-skills", prefix="skills")
+```
+
+### MinIO (and Other S3-Compatible Stores)
+
+Build a boto3 client pointed at your endpoint and pass it in. MinIO requires path-style addressing:
+
+```python
+import boto3
+from botocore.config import Config
+from pydantic_ai_skills.registries import S3SkillsRegistry
+
+client = boto3.client(
+    "s3",
+    endpoint_url="http://localhost:9000",
+    aws_access_key_id="minioadmin",
+    aws_secret_access_key="minioadmin",
+    config=Config(s3={"addressing_style": "path"}),
+)
+
+registry = S3SkillsRegistry(bucket="skills", boto3_client=client)
+```
+
+The same pattern works for Ceph RadosGW and Cloudflare R2 — only the `endpoint_url` and credentials change.
+
+### Offline / Air-Gapped Mode
+
+Set `auto_install=False` so the registry never reaches S3 and reads only from `target_dir`:
+
+```python
+registry = S3SkillsRegistry(
+    bucket="skills",
+    target_dir="/opt/skills-mirror",
+    auto_install=False,
+)
+```
+
+### Skill Metadata Enrichment
+
+Skills loaded from S3 receive registry-specific metadata:
+
+```python
+skill = await registry.get('pdf')
+print(skill.metadata)
+# {
+#     'source_url': 's3://my-skills/skills/pdf',
+#     'registry': 'S3SkillsRegistry',
+#     'bucket': 'my-skills',
+#     'prefix': 'skills',
+#     'version': '2024-01-01T00:00:00+00:00',  # latest object LastModified
 # }
 ```
 

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -203,7 +203,7 @@ The same pattern works for Ceph RadosGW and Cloudflare R2 — only the `endpoint
 
 ### Offline / Air-Gapped Mode
 
-Set `auto_install=False` so the registry never reaches S3 and reads only from `target_dir`:
+Set `auto_install=False` to disable automatic syncing on construction and on `search`/`get` — the registry then reads only what already exists in `target_dir` (e.g. a pre-mirrored copy). Note that an explicit `update()` call still contacts S3.
 
 ```python
 registry = S3SkillsRegistry(

--- a/pydantic_ai_skills/__init__.py
+++ b/pydantic_ai_skills/__init__.py
@@ -39,7 +39,7 @@ Example:
 from pydantic_ai_skills.capability import SkillsCapability
 from pydantic_ai_skills.directory import SkillsDirectory, discover_skills, parse_skill_md
 from pydantic_ai_skills.local import CallableSkillScriptExecutor, LocalSkillScriptExecutor
-from pydantic_ai_skills.registries import GitCloneOptions, GitSkillsRegistry, SkillRegistry
+from pydantic_ai_skills.registries import GitCloneOptions, GitSkillsRegistry, S3SkillsRegistry, SkillRegistry
 from pydantic_ai_skills.toolset import SkillsToolset
 from pydantic_ai_skills.types import Skill, SkillResource, SkillScript
 
@@ -60,6 +60,7 @@ __all__ = [
     'SkillRegistry',
     'GitSkillsRegistry',
     'GitCloneOptions',
+    'S3SkillsRegistry',
     # Utility functions
     'discover_skills',
     'parse_skill_md',

--- a/pydantic_ai_skills/registries/__init__.py
+++ b/pydantic_ai_skills/registries/__init__.py
@@ -3,6 +3,8 @@
 Available registries:
 - :class:`~pydantic_ai_skills.registries.git.GitSkillsRegistry`: Clone a Git repository
   and expose its skills.
+- :class:`~pydantic_ai_skills.registries.s3.S3SkillsRegistry`: Download skills from an S3
+  bucket (or S3-compatible store such as MinIO).
 
 Composition wrappers:
 - :class:`~pydantic_ai_skills.registries.wrapper.WrapperRegistry`: Base delegation wrapper.
@@ -21,6 +23,7 @@ from pydantic_ai_skills.registries.filtered import FilteredRegistry
 from pydantic_ai_skills.registries.git import GitCloneOptions, GitSkillsRegistry
 from pydantic_ai_skills.registries.prefixed import PrefixedRegistry
 from pydantic_ai_skills.registries.renamed import RenamedRegistry
+from pydantic_ai_skills.registries.s3 import S3SkillsRegistry
 from pydantic_ai_skills.registries.wrapper import WrapperRegistry
 
 __all__ = [
@@ -32,4 +35,5 @@ __all__ = [
     'CombinedRegistry',
     'GitSkillsRegistry',
     'GitCloneOptions',
+    'S3SkillsRegistry',
 ]

--- a/pydantic_ai_skills/registries/_copy.py
+++ b/pydantic_ai_skills/registries/_copy.py
@@ -1,0 +1,55 @@
+"""Shared filesystem helpers for copying skill directories into a target dir.
+
+Used by the concrete registries (e.g. :class:`GitSkillsRegistry`,
+:class:`S3SkillsRegistry`) to install a skill while enforcing path-traversal and
+symlink-escape protection.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+__all__ = ['copy_skill_directory']
+
+
+def copy_skill_directory(src_skill_dir: str | Path, target_dir: str | Path, skill_name: str) -> Path:
+    """Copy a skill directory into ``target_dir/skill_name`` with safety checks.
+
+    Args:
+        src_skill_dir: Source skill directory to copy from.
+        target_dir: Destination root directory; a ``skill_name`` subdirectory is
+            created inside it.
+        skill_name: Name of the skill (used as the destination subdirectory name).
+
+    Returns:
+        Path to the copied skill directory (``target_dir/skill_name``).
+
+    Raises:
+        ValueError: When the destination or any source path escapes its expected
+            directory (path traversal / symlink-escape protection).
+    """
+    dest_root = Path(target_dir).expanduser().resolve()
+    dest_root.mkdir(parents=True, exist_ok=True)
+    dest_skill_dir = dest_root / skill_name
+
+    # Path traversal check on destination.
+    if not dest_skill_dir.resolve().is_relative_to(dest_root):
+        raise ValueError(f"Destination path '{dest_skill_dir}' escapes target directory '{dest_root}'.")
+
+    # Validate no source symlinks escape the skill directory.
+    src_resolved = Path(src_skill_dir).resolve()
+    for src_file in src_resolved.rglob('*'):
+        if src_file.is_symlink() or src_file.is_file():
+            try:
+                src_file.resolve().relative_to(src_resolved)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Source path '{src_file}' escapes skill directory (path traversal detected)."
+                ) from exc
+
+    if dest_skill_dir.exists():
+        shutil.rmtree(dest_skill_dir)
+    shutil.copytree(src_resolved, dest_skill_dir)
+
+    return dest_skill_dir

--- a/pydantic_ai_skills/registries/git.py
+++ b/pydantic_ai_skills/registries/git.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse, urlunparse
 
 from pydantic_ai_skills.directory import discover_skills
 from pydantic_ai_skills.registries._base import SkillRegistry
+from pydantic_ai_skills.registries._copy import copy_skill_directory
 from pydantic_ai_skills.types import Skill
 
 __all__ = ['GitCloneOptions', 'GitSkillsRegistry']
@@ -577,31 +578,7 @@ class GitSkillsRegistry(SkillRegistry):
         if src_skill_dir is None:
             raise KeyError(f"Skill '{skill_name}' not found in repository {self._clean_repo_url!r}.")
 
-        dest_root = Path(target_dir).expanduser().resolve()
-        dest_root.mkdir(parents=True, exist_ok=True)
-        dest_skill_dir = dest_root / skill_name
-
-        # Path traversal check on destination
-        if not dest_skill_dir.resolve().is_relative_to(dest_root):
-            raise ValueError(f"Destination path '{dest_skill_dir}' escapes target directory '{dest_root}'.")
-
-        # Validate no source symlinks escape the skill directory
-        src_resolved = src_skill_dir.resolve()
-        for src_file in src_resolved.rglob('*'):
-            if src_file.is_symlink() or src_file.is_file():
-                try:
-                    src_file.resolve().relative_to(src_resolved)
-                except ValueError as exc:
-                    raise ValueError(
-                        f"Source path '{src_file}' escapes skill directory (path traversal detected)."
-                    ) from exc
-
-        # Copy the skill directory
-        if dest_skill_dir.exists():
-            shutil.rmtree(dest_skill_dir)
-        shutil.copytree(src_resolved, dest_skill_dir)
-
-        return dest_skill_dir
+        return copy_skill_directory(src_skill_dir, target_dir, skill_name)
 
     async def update(self, skill_name: str, target_dir: str | Path) -> Path:
         """Pull the latest changes and re-copy the skill to ``target_dir``.

--- a/pydantic_ai_skills/registries/s3.py
+++ b/pydantic_ai_skills/registries/s3.py
@@ -8,7 +8,6 @@ exposing them to :class:`~pydantic_ai_skills.SkillsToolset`.
 from __future__ import annotations
 
 import shutil
-import tempfile
 from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
@@ -16,6 +15,7 @@ from typing import Any
 
 from pydantic_ai_skills.directory import discover_skills
 from pydantic_ai_skills.registries._base import SkillRegistry
+from pydantic_ai_skills.registries._copy import copy_skill_directory
 from pydantic_ai_skills.types import Skill
 
 __all__ = ['S3SkillsRegistry']
@@ -27,7 +27,9 @@ class S3SkillsRegistry(SkillRegistry):
     Lists and downloads every object under ``bucket/prefix`` into a local cache
     directory on the first call to ``search``/``get``/``install`` (or eagerly
     during ``__init__`` when ``auto_install=True``), then parses the synced tree
-    with :func:`~pydantic_ai_skills.discover_skills`. Re-syncs on ``update``.
+    with :func:`~pydantic_ai_skills.discover_skills`. Each sync mirrors the
+    remote prefix — the cached subtree is cleared first, so skills removed from
+    the bucket no longer appear locally. Re-syncs on ``update``.
 
     Works with Amazon S3 and any S3-compatible store (MinIO, Ceph, Cloudflare R2,
     etc.). All connection details — credentials, ``endpoint_url``, region, TLS,
@@ -58,8 +60,9 @@ class S3SkillsRegistry(SkillRegistry):
             :class:`~pydantic_ai_skills.SkillsDirectory`. Defaults to ``True``.
         auto_install: When ``True`` (default), ``search`` and ``get`` trigger a
             sync automatically so the local copy is always up to date. Set to
-            ``False`` to require explicit ``install`` / ``update`` calls, which is
-            preferable in offline or air-gapped environments.
+            ``False`` to skip syncing on construction and on ``search`` / ``get``;
+            the registry then reads only what already exists in ``target_dir``.
+            Note that an explicit ``update()`` call always contacts S3.
 
     Examples:
         Amazon S3 with the ambient credential chain:
@@ -118,9 +121,13 @@ class S3SkillsRegistry(SkillRegistry):
         self._prefix = prefix.strip('/')
         self._validate = validate
         self._auto_install = auto_install
-        self._tmp_dir: tempfile.TemporaryDirectory[str] | None = None
+        self._tmp_dir: Any | None = None
+        # Cache of the most recent object listing (Key -> LastModified), populated by _sync.
+        self._object_modified: dict[str, datetime | None] = {}
 
         if target_dir is None:
+            import tempfile
+
             self._tmp_dir = tempfile.TemporaryDirectory()
             self._target_dir = Path(self._tmp_dir.name)
         else:
@@ -152,18 +159,36 @@ class S3SkillsRegistry(SkillRegistry):
     def _list_objects(self) -> list[dict[str, Any]]:
         """Return all object summaries under ``bucket/prefix`` via pagination."""
         list_prefix = f'{self._prefix}/' if self._prefix else ''
-        paginator = self._client.get_paginator('list_objects_v2')
-        objects: list[dict[str, Any]] = []
-        for page in paginator.paginate(Bucket=self._bucket, Prefix=list_prefix):
-            objects.extend(page.get('Contents', []))
-        return objects
+        try:
+            paginator = self._client.get_paginator('list_objects_v2')
+            objects: list[dict[str, Any]] = []
+            for page in paginator.paginate(Bucket=self._bucket, Prefix=list_prefix):
+                objects.extend(page.get('Contents', []))
+            return objects
+        except Exception as exc:  # surface any boto3/botocore error with context
+            raise RuntimeError(
+                f"Failed to list objects in bucket '{self._bucket}' (prefix '{self._prefix}'): {exc}"
+            ) from exc
 
     def _sync(self) -> None:
-        """Download all objects under ``bucket/prefix`` into ``target_dir``."""
+        """Mirror all objects under ``bucket/prefix`` into ``target_dir``.
+
+        Clears the cached prefix subtree first so skills removed from the bucket
+        do not linger locally, then downloads the current objects. The listing is
+        fetched once and cached for metadata enrichment.
+        """
+        objects = self._list_objects()
+        self._object_modified = {obj['Key']: obj.get('LastModified') for obj in objects}
+
+        # Mirror the remote: drop the previously synced subtree before re-downloading.
+        skills_root = self._skills_root()
+        if skills_root.exists():
+            shutil.rmtree(skills_root)
+
         self._target_dir.mkdir(parents=True, exist_ok=True)
         target_resolved = self._target_dir.resolve()
 
-        for obj in self._list_objects():
+        for obj in objects:
             key = obj['Key']
             if key.endswith('/'):
                 # Directory marker — nothing to download.
@@ -175,12 +200,10 @@ class S3SkillsRegistry(SkillRegistry):
                 raise ValueError(f"Object key '{key}' escapes target directory '{target_resolved}'.")
 
             dest.parent.mkdir(parents=True, exist_ok=True)
-            self._client.download_file(self._bucket, key, str(dest))
-
-    def _ensure_synced(self) -> None:
-        """Sync the cache when ``auto_install`` is enabled; otherwise trust on-disk state."""
-        if self._auto_install:
-            self._sync()
+            try:
+                self._client.download_file(self._bucket, key, str(dest))
+            except Exception as exc:  # surface any boto3/botocore error with context
+                raise RuntimeError(f"Failed to download '{key}' from bucket '{self._bucket}': {exc}") from exc
 
     def _load_skills(self) -> list[Skill]:
         """Discover all skills from the synced cache path."""
@@ -190,8 +213,12 @@ class S3SkillsRegistry(SkillRegistry):
         return discover_skills(path=skills_root, validate=self._validate, max_depth=2)
 
     def _skill_version(self, skill: Skill) -> str | None:
-        """Return the latest LastModified across the skill's objects, ISO-formatted."""
-        if not skill.uri:
+        """Return the latest LastModified across the skill's objects, ISO-formatted.
+
+        Uses the cached object listing from the most recent :meth:`_sync`, so it
+        performs no additional S3 calls.
+        """
+        if not skill.uri or not self._object_modified:
             return None
         try:
             skill_dir = Path(skill.uri).resolve().relative_to(self._target_dir.resolve())
@@ -199,11 +226,9 @@ class S3SkillsRegistry(SkillRegistry):
             return None
         key_prefix = f'{skill_dir.as_posix()}/'
         latest: datetime | None = None
-        for obj in self._list_objects():
-            if obj['Key'].startswith(key_prefix):
-                modified = obj.get('LastModified')
-                if modified is not None and (latest is None or modified > latest):
-                    latest = modified
+        for key, modified in self._object_modified.items():
+            if key.startswith(key_prefix) and modified is not None and (latest is None or modified > latest):
+                latest = modified
         return latest.isoformat() if latest is not None else None
 
     def _enrich_metadata(self, skill: Skill) -> Skill:
@@ -311,28 +336,7 @@ class S3SkillsRegistry(SkillRegistry):
         if src_skill_dir is None:
             raise KeyError(f"Skill '{skill_name}' not found in bucket '{self._bucket}'.")
 
-        dest_root = Path(target_dir).expanduser().resolve()
-        dest_root.mkdir(parents=True, exist_ok=True)
-        dest_skill_dir = dest_root / skill_name
-
-        if not dest_skill_dir.resolve().is_relative_to(dest_root):
-            raise ValueError(f"Destination path '{dest_skill_dir}' escapes target directory '{dest_root}'.")
-
-        src_resolved = src_skill_dir.resolve()
-        for src_file in src_resolved.rglob('*'):
-            if src_file.is_symlink() or src_file.is_file():
-                try:
-                    src_file.resolve().relative_to(src_resolved)
-                except ValueError as exc:
-                    raise ValueError(
-                        f"Source path '{src_file}' escapes skill directory (path traversal detected)."
-                    ) from exc
-
-        if dest_skill_dir.exists():
-            shutil.rmtree(dest_skill_dir)
-        shutil.copytree(src_resolved, dest_skill_dir)
-
-        return dest_skill_dir
+        return copy_skill_directory(src_skill_dir, target_dir, skill_name)
 
     async def update(self, skill_name: str, target_dir: str | Path) -> Path:
         """Re-sync from S3 and re-copy the skill to ``target_dir``.

--- a/pydantic_ai_skills/registries/s3.py
+++ b/pydantic_ai_skills/registries/s3.py
@@ -1,0 +1,359 @@
+"""S3-backed skill registry using boto3.
+
+Provides :class:`S3SkillsRegistry` for downloading skills from an Amazon S3
+bucket (or any S3-compatible store such as MinIO, Ceph, or Cloudflare R2) and
+exposing them to :class:`~pydantic_ai_skills.SkillsToolset`.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from dataclasses import replace
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic_ai_skills.directory import discover_skills
+from pydantic_ai_skills.registries._base import SkillRegistry
+from pydantic_ai_skills.types import Skill
+
+__all__ = ['S3SkillsRegistry']
+
+
+class S3SkillsRegistry(SkillRegistry):
+    """Skills registry backed by an S3 bucket, downloaded with boto3.
+
+    Lists and downloads every object under ``bucket/prefix`` into a local cache
+    directory on the first call to ``search``/``get``/``install`` (or eagerly
+    during ``__init__`` when ``auto_install=True``), then parses the synced tree
+    with :func:`~pydantic_ai_skills.discover_skills`. Re-syncs on ``update``.
+
+    Works with Amazon S3 and any S3-compatible store (MinIO, Ceph, Cloudflare R2,
+    etc.). All connection details — credentials, ``endpoint_url``, region, TLS,
+    and path-style addressing — are configured on the boto3 client you pass via
+    ``boto3_client``. When omitted, a default ``boto3.client("s3")`` is built,
+    which uses boto3's standard credential resolution chain.
+
+    ``search()`` and ``get()`` return :class:`~pydantic_ai_skills.Skill` objects
+    parsed from ``SKILL.md`` frontmatter + body. Registry-specific metadata
+    (``source_url``, ``version``, ``bucket``, ``prefix``) is stored in
+    ``skill.metadata``.
+
+    Args:
+        bucket: Name of the S3 bucket containing the skills.
+        prefix: Key prefix inside the bucket where skill directories live.
+            Defaults to the bucket root (``""``). For example, pass ``"skills"``
+            when skills live at ``s3://bucket/skills/<skill>/``.
+        target_dir: Local directory where objects are downloaded. Defaults to a
+            temporary directory scoped to the registry instance. The synced tree
+            persists across ``install`` / ``update`` calls but is **not** cleaned
+            up automatically — callers own the lifecycle.
+        boto3_client: A pre-built boto3 S3 client. Use this to configure
+            credentials, ``endpoint_url`` (for MinIO/Ceph/R2), region, TLS, and
+            path-style addressing. When ``None``, a default ``boto3.client("s3")``
+            is created (requires the ``s3`` extra: ``pip install pydantic-ai-skills[s3]``).
+        validate: Whether to run metadata validation on every discovered
+            ``SKILL.md`` after syncing. Mirrors the homonymous flag on
+            :class:`~pydantic_ai_skills.SkillsDirectory`. Defaults to ``True``.
+        auto_install: When ``True`` (default), ``search`` and ``get`` trigger a
+            sync automatically so the local copy is always up to date. Set to
+            ``False`` to require explicit ``install`` / ``update`` calls, which is
+            preferable in offline or air-gapped environments.
+
+    Examples:
+        Amazon S3 with the ambient credential chain:
+
+        ```python
+        from pydantic_ai_skills import SkillsToolset
+        from pydantic_ai_skills.registries.s3 import S3SkillsRegistry
+
+        toolset = SkillsToolset(
+            registries=[S3SkillsRegistry(bucket="my-skills", prefix="skills")]
+        )
+        ```
+
+        MinIO (or any S3-compatible store) with a custom client:
+
+        ```python
+        import boto3
+        from botocore.config import Config
+        from pydantic_ai_skills.registries.s3 import S3SkillsRegistry
+
+        client = boto3.client(
+            "s3",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id="minioadmin",
+            aws_secret_access_key="minioadmin",
+            config=Config(s3={"addressing_style": "path"}),
+        )
+        registry = S3SkillsRegistry(bucket="skills", boto3_client=client)
+        ```
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        prefix: str = '',
+        target_dir: str | Path | None = None,
+        boto3_client: Any | None = None,
+        validate: bool = True,
+        auto_install: bool = True,
+    ) -> None:
+        if boto3_client is None:
+            try:
+                import boto3
+            except ImportError as exc:
+                raise ImportError(
+                    'boto3 is required to build a default S3 client for S3SkillsRegistry. '
+                    'Install it with: pip install pydantic-ai-skills[s3], or pass a pre-built '
+                    'boto3_client.'
+                ) from exc
+            self._client = boto3.client('s3')
+        else:
+            self._client = boto3_client
+
+        self._bucket = bucket
+        self._prefix = prefix.strip('/')
+        self._validate = validate
+        self._auto_install = auto_install
+        self._tmp_dir: tempfile.TemporaryDirectory[str] | None = None
+
+        if target_dir is None:
+            self._tmp_dir = tempfile.TemporaryDirectory()
+            self._target_dir = Path(self._tmp_dir.name)
+        else:
+            self._target_dir = Path(target_dir).expanduser().resolve()
+
+        self._cached_skills: list[Skill] = []
+        if self._auto_install:
+            self._sync()
+            self._cached_skills = [self._enrich_metadata(s) for s in self._load_skills()]
+
+    def __repr__(self) -> str:
+        return (
+            f'{type(self).__name__}('
+            f'bucket={self._bucket!r}, '
+            f'prefix={self._prefix!r}, '
+            f'target_dir={str(self._target_dir)!r})'
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _skills_root(self) -> Path:
+        """Return the path inside the cache where skill directories live."""
+        if self._prefix:
+            return self._target_dir / self._prefix
+        return self._target_dir
+
+    def _list_objects(self) -> list[dict[str, Any]]:
+        """Return all object summaries under ``bucket/prefix`` via pagination."""
+        list_prefix = f'{self._prefix}/' if self._prefix else ''
+        paginator = self._client.get_paginator('list_objects_v2')
+        objects: list[dict[str, Any]] = []
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=list_prefix):
+            objects.extend(page.get('Contents', []))
+        return objects
+
+    def _sync(self) -> None:
+        """Download all objects under ``bucket/prefix`` into ``target_dir``."""
+        self._target_dir.mkdir(parents=True, exist_ok=True)
+        target_resolved = self._target_dir.resolve()
+
+        for obj in self._list_objects():
+            key = obj['Key']
+            if key.endswith('/'):
+                # Directory marker — nothing to download.
+                continue
+
+            dest = self._target_dir / key
+            # Path-traversal guard: the resolved destination must stay inside target_dir.
+            if not dest.resolve().is_relative_to(target_resolved):
+                raise ValueError(f"Object key '{key}' escapes target directory '{target_resolved}'.")
+
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            self._client.download_file(self._bucket, key, str(dest))
+
+    def _ensure_synced(self) -> None:
+        """Sync the cache when ``auto_install`` is enabled; otherwise trust on-disk state."""
+        if self._auto_install:
+            self._sync()
+
+    def _load_skills(self) -> list[Skill]:
+        """Discover all skills from the synced cache path."""
+        skills_root = self._skills_root()
+        if not skills_root.exists():
+            return []
+        return discover_skills(path=skills_root, validate=self._validate, max_depth=2)
+
+    def _skill_version(self, skill: Skill) -> str | None:
+        """Return the latest LastModified across the skill's objects, ISO-formatted."""
+        if not skill.uri:
+            return None
+        try:
+            skill_dir = Path(skill.uri).resolve().relative_to(self._target_dir.resolve())
+        except ValueError:
+            return None
+        key_prefix = f'{skill_dir.as_posix()}/'
+        latest: datetime | None = None
+        for obj in self._list_objects():
+            if obj['Key'].startswith(key_prefix):
+                modified = obj.get('LastModified')
+                if modified is not None and (latest is None or modified > latest):
+                    latest = modified
+        return latest.isoformat() if latest is not None else None
+
+    def _enrich_metadata(self, skill: Skill) -> Skill:
+        """Inject registry-specific keys into ``skill.metadata``."""
+        skill_path = f'{self._prefix}/{skill.name}'.strip('/')
+        extra: dict[str, Any] = {
+            'source_url': f's3://{self._bucket}/{skill_path}',
+            'registry': type(self).__name__,
+            'bucket': self._bucket,
+            'prefix': self._prefix,
+            'version': self._skill_version(skill),
+        }
+        existing = dict(skill.metadata) if skill.metadata else {}
+        existing.update(extra)
+        return replace(skill, metadata=existing)
+
+    def _ensure_skills_loaded(self) -> None:
+        """Populate the skills cache if empty, respecting ``auto_install``."""
+        if self._cached_skills:
+            return
+        if self._auto_install:
+            self._sync()
+        self._cached_skills = [self._enrich_metadata(s) for s in self._load_skills()]
+
+    # ------------------------------------------------------------------
+    # Synchronous skill access for SkillsToolset integration
+    # ------------------------------------------------------------------
+
+    def get_skills(self) -> list[Skill]:
+        """Return all skills discovered from the bucket.
+
+        Returns:
+            List of enriched :class:`~pydantic_ai_skills.Skill` objects.
+        """
+        self._ensure_skills_loaded()
+        return list(self._cached_skills)
+
+    # ------------------------------------------------------------------
+    # SkillRegistry interface
+    # ------------------------------------------------------------------
+
+    async def search(self, query: str, limit: int = 10) -> list[Skill]:
+        """Search available skills by keyword.
+
+        Matches ``query`` (case-insensitively) against each skill's ``name`` and
+        ``description``.
+
+        Args:
+            query: Keyword to search for.
+            limit: Maximum number of results.
+
+        Returns:
+            List of matching :class:`~pydantic_ai_skills.Skill` objects.
+        """
+        q = query.lower()
+        results: list[Skill] = []
+        for skill in self.get_skills():
+            if q in skill.name.lower() or q in (skill.description or '').lower():
+                results.append(skill)
+                if len(results) >= limit:
+                    break
+        return results
+
+    async def get(self, skill_name: str) -> Skill:
+        """Return the full skill by name.
+
+        Args:
+            skill_name: Exact skill name.
+
+        Returns:
+            A fully-parsed :class:`~pydantic_ai_skills.Skill`.
+
+        Raises:
+            KeyError: When no skill with ``skill_name`` exists.
+        """
+        for skill in self.get_skills():
+            if skill.name == skill_name:
+                return skill
+        raise KeyError(f"Skill '{skill_name}' not found in bucket '{self._bucket}'.")
+
+    async def install(self, skill_name: str, target_dir: str | Path) -> Path:
+        """Copy a skill from the synced cache into ``target_dir``.
+
+        Args:
+            skill_name: Name of the skill to install.
+            target_dir: Destination directory; a ``skill_name`` subdirectory is
+                created inside it.
+
+        Returns:
+            Path to the installed skill directory (``target_dir/skill_name``).
+
+        Raises:
+            KeyError: When ``skill_name`` is not found in the registry.
+            ValueError: When the destination or source path escapes its expected
+                directory (path traversal protection).
+        """
+        self._ensure_skills_loaded()
+
+        src_skill_dir: Path | None = None
+        for skill in self._cached_skills:
+            if skill.name == skill_name and skill.uri:
+                src_skill_dir = Path(skill.uri)
+                break
+
+        if src_skill_dir is None:
+            raise KeyError(f"Skill '{skill_name}' not found in bucket '{self._bucket}'.")
+
+        dest_root = Path(target_dir).expanduser().resolve()
+        dest_root.mkdir(parents=True, exist_ok=True)
+        dest_skill_dir = dest_root / skill_name
+
+        if not dest_skill_dir.resolve().is_relative_to(dest_root):
+            raise ValueError(f"Destination path '{dest_skill_dir}' escapes target directory '{dest_root}'.")
+
+        src_resolved = src_skill_dir.resolve()
+        for src_file in src_resolved.rglob('*'):
+            if src_file.is_symlink() or src_file.is_file():
+                try:
+                    src_file.resolve().relative_to(src_resolved)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Source path '{src_file}' escapes skill directory (path traversal detected)."
+                    ) from exc
+
+        if dest_skill_dir.exists():
+            shutil.rmtree(dest_skill_dir)
+        shutil.copytree(src_resolved, dest_skill_dir)
+
+        return dest_skill_dir
+
+    async def update(self, skill_name: str, target_dir: str | Path) -> Path:
+        """Re-sync from S3 and re-copy the skill to ``target_dir``.
+
+        Performs a fresh sync of the cache before re-installing. Falls back to a
+        plain ``install`` if the skill is not yet installed.
+
+        Args:
+            skill_name: Name of the skill to update.
+            target_dir: Directory where the skill was previously installed.
+
+        Returns:
+            Path to the updated skill directory.
+
+        Raises:
+            KeyError: When ``skill_name`` is not found after the sync.
+        """
+        dest = Path(target_dir).expanduser().resolve() / skill_name
+        if not dest.exists():
+            return await self.install(skill_name, target_dir)
+
+        self._sync()
+        self._cached_skills = [self._enrich_metadata(s) for s in self._load_skills()]
+        return await self.install(skill_name, target_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ docs = [
 git = [
     "gitpython>=3.1.40",
 ]
+s3 = [
+    "boto3>=1.26.0",
+]
 test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,11 @@ quote-style = "single"
 
 [tool.hatch.build.targets.wheel]
 packages = ["pydantic_ai_skills"]
+
+[tool.coverage.run]
+# Emit repo-root-relative file paths (e.g. pydantic_ai_skills/registries/s3.py)
+# so SonarCloud can map coverage entries onto the indexed sources. Without this,
+# coverage.xml records paths relative to the package dir (registries/s3.py),
+# which Sonar resolves from the repo root and fails to match -> 0% coverage.
+relative_files = true
+source = ["pydantic_ai_skills"]

--- a/tests/test_s3_registry.py
+++ b/tests/test_s3_registry.py
@@ -1,0 +1,262 @@
+"""Tests for S3SkillsRegistry."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from pydantic_ai_skills.registries.s3 import S3SkillsRegistry
+
+# ---------------------------------------------------------------------------
+# Fake boto3 S3 client
+# ---------------------------------------------------------------------------
+
+
+class _FakePaginator:
+    def __init__(self, store: dict[str, bytes], modified: datetime) -> None:
+        self._store = store
+        self._modified = modified
+
+    def paginate(self, *, Bucket: str, Prefix: str) -> list[dict[str, Any]]:
+        contents = [{'Key': key, 'LastModified': self._modified} for key in self._store if key.startswith(Prefix)]
+        # Split across two pages to exercise pagination handling.
+        mid = len(contents) // 2 or len(contents)
+        return [{'Contents': contents[:mid]}, {'Contents': contents[mid:]}]
+
+
+class FakeS3Client:
+    """Minimal in-memory stand-in for a boto3 S3 client."""
+
+    def __init__(self, store: dict[str, bytes] | None = None) -> None:
+        self.store: dict[str, bytes] = dict(store or {})
+        self.modified = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        self.secret = 'super-secret-key'
+
+    def get_paginator(self, name: str) -> _FakePaginator:
+        assert name == 'list_objects_v2'
+        return _FakePaginator(self.store, self.modified)
+
+    def download_file(self, Bucket: str, Key: str, Filename: str) -> None:
+        Path(Filename).write_bytes(self.store[Key])
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _skill_md(name: str, description: str) -> bytes:
+    return f'---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n\nInstructions here.\n'.encode()
+
+
+@pytest.fixture()
+def client() -> FakeS3Client:
+    """Fake client with two skills under the ``skills/`` prefix."""
+    return FakeS3Client(
+        {
+            'skills/pdf/SKILL.md': _skill_md('pdf', 'PDF manipulation skill.'),
+            'skills/xlsx/SKILL.md': _skill_md('xlsx', 'Excel spreadsheet skill.'),
+        }
+    )
+
+
+def _make_registry(client: FakeS3Client, **kwargs: Any) -> S3SkillsRegistry:
+    return S3SkillsRegistry(bucket='my-bucket', prefix='skills', boto3_client=client, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Construction / client injection
+# ---------------------------------------------------------------------------
+
+
+def test_import_error_when_boto3_missing_and_no_client() -> None:
+    """Building a default client without boto3 installed raises a helpful ImportError."""
+    with patch.dict('sys.modules', {'boto3': None}):
+        with pytest.raises(ImportError, match=r'pip install pydantic-ai-skills\[s3\]'):
+            S3SkillsRegistry(bucket='my-bucket')
+
+
+def test_repr_does_not_leak_client_or_credentials(client: FakeS3Client) -> None:
+    """__repr__ shows bucket/prefix/target_dir but never the client or its credentials."""
+    registry = _make_registry(client)
+    result = repr(registry)
+    assert 'my-bucket' in result
+    assert 'skills' in result
+    assert 'super-secret-key' not in result
+    assert 'FakeS3Client' not in result
+
+
+def test_injected_client_skips_boto3_import(client: FakeS3Client) -> None:
+    """A supplied client works even when boto3 cannot be imported."""
+    with patch.dict('sys.modules', {'boto3': None}):
+        registry = _make_registry(client)
+    assert {s.name for s in registry.get_skills()} == {'pdf', 'xlsx'}
+
+
+# ---------------------------------------------------------------------------
+# get_skills / search / get
+# ---------------------------------------------------------------------------
+
+
+def test_get_skills_returns_all(client: FakeS3Client) -> None:
+    """get_skills returns every skill synced from the bucket."""
+    registry = _make_registry(client)
+    assert {s.name for s in registry.get_skills()} == {'pdf', 'xlsx'}
+
+
+async def test_search_returns_matching_skills(client: FakeS3Client) -> None:
+    """Search returns skills whose name matches the query."""
+    registry = _make_registry(client)
+    results = await registry.search('pdf')
+    assert [s.name for s in results] == ['pdf']
+
+
+async def test_search_is_case_insensitive(client: FakeS3Client) -> None:
+    """Search matching ignores case for both name and description."""
+    registry = _make_registry(client)
+    results = await registry.search('EXCEL')
+    assert [s.name for s in results] == ['xlsx']
+
+
+async def test_search_respects_limit(client: FakeS3Client) -> None:
+    """Search returns at most *limit* results."""
+    registry = _make_registry(client)
+    results = await registry.search('skill', limit=1)
+    assert len(results) == 1
+
+
+async def test_get_returns_skill_by_name(client: FakeS3Client) -> None:
+    """Get returns the skill matching the exact name."""
+    registry = _make_registry(client)
+    skill = await registry.get('pdf')
+    assert skill.name == 'pdf'
+
+
+async def test_get_raises_for_unknown_skill(client: FakeS3Client) -> None:
+    """Get raises KeyError when the skill name is not present."""
+    registry = _make_registry(client)
+    with pytest.raises(KeyError):
+        await registry.get('nonexistent')
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+async def test_metadata_contains_registry_keys(client: FakeS3Client) -> None:
+    """Enriched skills carry registry, bucket, prefix, source_url, and version metadata."""
+    registry = _make_registry(client)
+    skill = await registry.get('pdf')
+    assert skill.metadata is not None
+    assert skill.metadata['registry'] == 'S3SkillsRegistry'
+    assert skill.metadata['bucket'] == 'my-bucket'
+    assert skill.metadata['prefix'] == 'skills'
+    assert skill.metadata['source_url'] == 's3://my-bucket/skills/pdf'
+    assert skill.metadata['version'] == '2024-01-01T00:00:00+00:00'
+
+
+# ---------------------------------------------------------------------------
+# Prefix scoping
+# ---------------------------------------------------------------------------
+
+
+def test_empty_prefix_lists_root() -> None:
+    """An empty prefix discovers skills at the bucket root."""
+    client = FakeS3Client({'pdf/SKILL.md': _skill_md('pdf', 'PDF skill.')})
+    registry = S3SkillsRegistry(bucket='my-bucket', prefix='', boto3_client=client)
+    assert {s.name for s in registry.get_skills()} == {'pdf'}
+
+
+# ---------------------------------------------------------------------------
+# install / update
+# ---------------------------------------------------------------------------
+
+
+async def test_install_copies_skill_directory(client: FakeS3Client, tmp_path: Path) -> None:
+    """Install copies a skill's files into a named subdirectory of the target."""
+    registry = _make_registry(client)
+    dest = await registry.install('pdf', tmp_path / 'installed')
+    assert dest == (tmp_path / 'installed' / 'pdf').resolve()
+    assert (dest / 'SKILL.md').exists()
+
+
+async def test_install_raises_for_unknown_skill(client: FakeS3Client, tmp_path: Path) -> None:
+    """Install raises KeyError for a skill that is not in the registry."""
+    registry = _make_registry(client)
+    with pytest.raises(KeyError):
+        await registry.install('nonexistent', tmp_path)
+
+
+async def test_update_installs_when_not_present(client: FakeS3Client, tmp_path: Path) -> None:
+    """Update falls back to a plain install when the skill is not yet installed."""
+    registry = _make_registry(client)
+    dest = await registry.update('pdf', tmp_path / 'installed')
+    assert (dest / 'SKILL.md').exists()
+
+
+async def test_update_resyncs_and_reinstalls(client: FakeS3Client, tmp_path: Path) -> None:
+    """Update re-syncs from S3 and re-copies an already-installed skill."""
+    registry = _make_registry(client)
+    target = tmp_path / 'installed'
+    await registry.install('pdf', target)
+    dest = await registry.update('pdf', target)
+    assert (dest / 'SKILL.md').exists()
+
+
+# ---------------------------------------------------------------------------
+# auto_install
+# ---------------------------------------------------------------------------
+
+
+def test_auto_install_false_does_not_sync(client: FakeS3Client, tmp_path: Path) -> None:
+    """With auto_install disabled, no sync happens and an empty cache yields no skills."""
+    registry = S3SkillsRegistry(
+        bucket='my-bucket',
+        prefix='skills',
+        target_dir=tmp_path / 'cache',
+        boto3_client=client,
+        auto_install=False,
+    )
+    # Nothing on disk yet → no skills.
+    assert registry.get_skills() == []
+
+
+# ---------------------------------------------------------------------------
+# Path traversal protection
+# ---------------------------------------------------------------------------
+
+
+def test_sync_rejects_path_traversal_key(tmp_path: Path) -> None:
+    """A malicious object key that escapes the target directory raises ValueError."""
+    client = FakeS3Client({'../evil/SKILL.md': _skill_md('evil', 'escape attempt')})
+    with pytest.raises(ValueError, match='escapes target directory'):
+        S3SkillsRegistry(
+            bucket='my-bucket',
+            prefix='',
+            target_dir=tmp_path / 'cache',
+            boto3_client=client,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Imports
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_import() -> None:
+    """S3SkillsRegistry is exported from the top-level package."""
+    from pydantic_ai_skills import S3SkillsRegistry as TopLevel
+
+    assert TopLevel is S3SkillsRegistry
+
+
+def test_registries_module_import() -> None:
+    """S3SkillsRegistry is exported from the registries module."""
+    from pydantic_ai_skills.registries import S3SkillsRegistry as FromRegistries
+
+    assert FromRegistries is S3SkillsRegistry

--- a/tests/test_s3_registry.py
+++ b/tests/test_s3_registry.py
@@ -208,6 +208,49 @@ async def test_update_resyncs_and_reinstalls(client: FakeS3Client, tmp_path: Pat
     assert (dest / 'SKILL.md').exists()
 
 
+async def test_update_mirrors_removed_skill(client: FakeS3Client, tmp_path: Path) -> None:
+    """A skill deleted from the bucket disappears locally after the next sync."""
+    registry = _make_registry(client)
+    assert {s.name for s in registry.get_skills()} == {'pdf', 'xlsx'}
+
+    target = tmp_path / 'installed'
+    await registry.install('pdf', target)
+
+    # Remove xlsx from the bucket, then trigger a re-sync via update.
+    del client.store['skills/xlsx/SKILL.md']
+    await registry.update('pdf', target)
+
+    assert {s.name for s in registry.get_skills()} == {'pdf'}
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_list_failure_wrapped_in_runtime_error(tmp_path: Path) -> None:
+    """A client error during listing is wrapped in RuntimeError with context."""
+
+    class FailingListClient(FakeS3Client):
+        def get_paginator(self, name: str) -> Any:
+            raise RuntimeError('boom: access denied')
+
+    with pytest.raises(RuntimeError, match="Failed to list objects in bucket 'my-bucket'"):
+        S3SkillsRegistry(bucket='my-bucket', prefix='skills', boto3_client=FailingListClient())
+
+
+def test_download_failure_wrapped_in_runtime_error(client: FakeS3Client) -> None:
+    """A client error during download is wrapped in RuntimeError with context."""
+
+    class FailingDownloadClient(FakeS3Client):
+        def download_file(self, Bucket: str, Key: str, Filename: str) -> None:
+            raise RuntimeError('boom: timeout')
+
+    failing = FailingDownloadClient(client.store)
+    with pytest.raises(RuntimeError, match="Failed to download .* from bucket 'my-bucket'"):
+        S3SkillsRegistry(bucket='my-bucket', prefix='skills', boto3_client=failing)
+
+
 # ---------------------------------------------------------------------------
 # auto_install
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `S3SkillsRegistry`, a skills registry backed by Amazon S3 and S3-compatible object stores (MinIO, Ceph, Cloudflare R2). It mirrors the existing `GitSkillsRegistry`: it downloads all objects under a `bucket`/`prefix` into a local cache and reuses `discover_skills()` to parse `SKILL.md` files.

Fixes #47

## What changed

- **`pydantic_ai_skills/registries/s3.py`** (new) — `S3SkillsRegistry(SkillRegistry)` implementing `search`/`get`/`install`/`update`/`get_skills`, with path-traversal + symlink-escape protection on download and copy, and metadata enrichment (`source_url`, `registry`, `bucket`, `prefix`, `version` from latest `LastModified`).
- **Client injection** — all connection details (credentials, `endpoint_url`, region, path-style addressing) come from a caller-built `boto3_client`. A default `boto3.client("s3")` is built lazily only when no client is passed, so importing the package never requires boto3.
- **`pyproject.toml`** — new optional `[s3]` extra (`boto3>=1.26.0`).
- **Exports** — `S3SkillsRegistry` exported from the top-level package and the `registries` module.
- **`tests/test_s3_registry.py`** (new, 19 tests) — in-memory fake boto3 client injected via `boto3_client`; covers happy path, prefix scoping, `auto_install=False`, the default-client import guard, path-traversal rejection, and credential-safe `repr`.
- **Docs** — `docs/registries.md` and `docs/api/registries.md` updated, including a MinIO custom-client example and the `[s3]` install note.

## Reviewer notes

- Constructor: `S3SkillsRegistry(bucket, *, prefix='', target_dir=None, boto3_client=None, validate=True, auto_install=True)`.
- For MinIO/S3-compatible stores, pass a boto3 client with `endpoint_url` and `Config(s3={"addressing_style": "path"})`.
- Nothing secret is stored on the instance; credentials live entirely in the caller's client.

## Test plan

- [x] `pytest -m "not slow"` — 429 passed
- [x] `ruff check` / `ruff format --check` clean; pre-commit (incl. mypy) passes
- [x] Import-safe without boto3 (default client built lazily)
- [ ] Optional: end-to-end against a local MinIO container

🤖 Generated with [Claude Code](https://claude.com/claude-code)