### PR TITLE
feat: adopt Pydantic AI v2 capabilities API [DEV-1215]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,13 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   test:
-    name: Test (Python ${{ matrix.python-version }})
+    name: Test (Python ${{ matrix.python-version }}, pydantic-ai ${{ matrix.pydantic-ai-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        pydantic-ai-version: ["1.105.0", "2.0.0", "latest"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,11 +44,20 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[test,git]"
 
+      - name: Select pydantic-ai-slim version
+        run: |
+          if [ "${{ matrix.pydantic-ai-version }}" = "latest" ]; then
+            uv pip install --system --upgrade pydantic-ai-slim
+          else
+            uv pip install --system "pydantic-ai-slim==${{ matrix.pydantic-ai-version }}"
+          fi
+          uv pip show pydantic-ai-slim | grep -i '^version'
+
       - name: Run pytest with coverage
         run: pytest --cov-report=xml
 
       - name: Upload coverage artifact
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.12' && matrix.pydantic-ai-version == '2.0.0'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ github.run_id }}
@@ -55,7 +65,7 @@ jobs:
           retention-days: 7
 
       - name: Save PR metadata
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.12' && matrix.pydantic-ai-version == '2.0.0'
         run: |
           echo "PR_NUMBER=${{ github.event.pull_request.number }}" > pr-metadata.env
           echo "PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> pr-metadata.env
@@ -63,7 +73,7 @@ jobs:
           echo "PR_HEAD_REF=${{ github.event.pull_request.head.ref }}" >> pr-metadata.env
 
       - name: Upload PR metadata artifact
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.12' && matrix.pydantic-ai-version == '2.0.0'
         uses: actions/upload-artifact@v4
         with:
           name: pr-metadata-${{ github.run_id }}

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -92,7 +92,7 @@ The `@toolset.skill()` decorator enables defining skills directly on a `SkillsTo
 
 ```python
 from pydantic_ai import Agent, RunContext
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 skills = SkillsToolset()
 
@@ -212,7 +212,7 @@ By default, `SkillsToolset` injects a standard instruction template that explain
 
 ```python
 from pydantic_ai import Agent
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 custom_template = """\
 You have access to specialized skills for domain-specific knowledge.
@@ -299,7 +299,7 @@ Both `@skill.resource` and `@skill.script` decorated functions can optionally ac
 ```python
 from typing import TypedDict
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 class MyDeps(TypedDict):
     """Dependencies available in RunContext."""
@@ -456,7 +456,7 @@ class SkillScriptExecutor(Protocol):
 ### Example: Remote Execution
 
 ```python
-from pydantic_ai.toolsets.skills import SkillScript, CallableSkillScriptExecutor
+from pydantic_ai_skills import SkillScript, CallableSkillScriptExecutor
 import httpx
 
 class RemoteExecutor:
@@ -478,7 +478,7 @@ class RemoteExecutor:
             return response.text
 
 # Use in custom script definitions
-from pydantic_ai.toolsets.skills import SkillScript
+from pydantic_ai_skills import SkillScript
 
 remote_executor = RemoteExecutor("https://api.example.com")
 
@@ -576,7 +576,7 @@ The real power comes when combining both approaches:
 
 ```python
 from pydantic_ai import Agent
-from pydantic_ai.toolsets.skills import SkillsToolset, Skill
+from pydantic_ai_skills import SkillsToolset, Skill
 
 # Create programmatic skills
 skills = SkillsToolset(
@@ -623,7 +623,7 @@ def conflicting_skill() -> str:
 You can programmatically register skills after toolset creation (though typically skills are defined at initialization):
 
 ```python
-from pydantic_ai.toolsets.skills import Skill
+from pydantic_ai_skills import Skill
 
 # Create toolset
 toolset = SkillsToolset()

--- a/docs/api/toolset.md
+++ b/docs/api/toolset.md
@@ -60,7 +60,7 @@ toolset = SkillsToolset(
 )
 
 # Using SkillsDirectory instances directly
-from pydantic_ai.toolsets.skills import SkillsDirectory
+from pydantic_ai_skills import SkillsDirectory
 
 skills_dir = SkillsDirectory(
     path="./skills",
@@ -99,7 +99,7 @@ See [Skill Registries](../registries.md) for composition patterns (filtering, pr
 
 ```python
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import Skill, SkillsToolset
+from pydantic_ai_skills import Skill, SkillsToolset
 
 # Create a simple programmatic skill
 my_skill = Skill(
@@ -133,7 +133,7 @@ async def analyze(ctx: RunContext[MyDeps], query: str) -> str:
 ### Mix File-Based and Programmatic Skills
 
 ```python
-from pydantic_ai.toolsets.skills import Skill, SkillsToolset
+from pydantic_ai_skills import Skill, SkillsToolset
 
 # Create programmatic skills
 programmatic_skill = Skill(
@@ -161,7 +161,7 @@ print(f"Total skills loaded: {len(toolset.skills)}")
 
 ```python
 from pydantic_ai import Agent
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 custom_instructions = """\
 You have specialized skills available for specific domains.
@@ -188,7 +188,7 @@ agent = Agent(
 ### Use @skill() Decorator
 
 ```python
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 skills = SkillsToolset(directories=["./skills"])
 
@@ -368,7 +368,7 @@ def skill(
 **Example**:
 
 ```python
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 skills = SkillsToolset()
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -215,7 +215,7 @@ When creating skills, these metadata fields are commonly used:
 
 ```python
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import Skill, SkillResource
+from pydantic_ai_skills import Skill, SkillResource
 
 # Create a skill with static resources
 my_skill = Skill(
@@ -289,7 +289,7 @@ for name, skill in toolset.skills.items():
 
 ```python
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import Skill, SkillsToolset
+from pydantic_ai_skills import Skill, SkillsToolset
 
 # Create programmatic skill
 custom_skill = Skill(

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -197,7 +197,7 @@ from pydantic_ai_skills import SkillResource
 resource = SkillResource(
     name="reference.md",
     description="Reference material",
-    content=None,  # Lazy-loaded for file-based resources
+    content="# Schema definitions...",  # or pass a file `uri` / callable `function`
 )
 ```
 
@@ -209,6 +209,7 @@ from pydantic_ai_skills import SkillScript
 script = SkillScript(
     name="my_script",
     description="Runs an analysis",
+    uri="scripts/my_script.py",  # file-based; or pass a callable `function`
     skill_name="my-skill",
 )
 ```

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -59,6 +59,28 @@ agent = Agent(
 )
 ```
 
+#### Deferred loading
+
+Pydantic AI v2 lets a capability stay hidden until the model explicitly loads it via the
+agent's built-in `load_capability` tool. Set `defer_loading=True` and give the capability a
+stable `id`:
+
+```python
+agent = Agent(
+    model='openai:gpt-5.2',
+    capabilities=[
+        SkillsCapability(id='skills', directories=['./skills'], defer_loading=True),
+    ],
+)
+```
+
+When deferred, the skills tools and instructions are collapsed to a one-line catalog entry
+(derived from the skill names, or set `description=...` to override) and only activate after
+the model loads the capability. This complements the toolset's own progressive disclosure
+(`list_skills` → `load_skill`): `defer_loading` gates the *entire skills system* behind one
+catalog entry, which is useful when an agent bundles many capabilities and most turns need
+none of the skills.
+
 ## SKILL.md Format
 
 Each `SKILL.md` file has **YAML frontmatter** (metadata) followed by **Markdown** (instructions).
@@ -145,24 +167,12 @@ skill_dir = SkillsDirectory(path="./skills", validate=True)
 all_skills = skill_dir.get_skills()
 
 for name, skill in all_skills.items():
-    print(f"{name}: {skill.metadata.description}")
+    print(f"{name}: {skill.description}")
 ```
 
 ## Type Safety
 
 The package provides type-safe dataclasses for working with skills:
-
-### SkillMetadata
-
-```python
-from pydantic_ai_skills import SkillMetadata
-
-metadata = SkillMetadata(
-    name="my-skill",
-    description="My skill description",
-    extra={"version": "1.0.0", "author": "Me"}
-)
-```
 
 ### Skill
 
@@ -171,11 +181,11 @@ from pydantic_ai_skills import Skill
 
 skill = Skill(
     name="my-skill",
-    path=Path("./skills/my-skill"),
-    metadata=metadata,
+    description="My skill description",
     content="# Instructions...",
     resources=[...],
-    scripts=[...]
+    scripts=[...],
+    metadata={"version": "1.0.0", "author": "Me"},
 )
 ```
 
@@ -186,8 +196,8 @@ from pydantic_ai_skills import SkillResource
 
 resource = SkillResource(
     name="reference.md",
-    path=Path("./skills/my-skill/resources/reference.md"),
-    content=None  # Lazy-loaded
+    description="Reference material",
+    content=None,  # Lazy-loaded for file-based resources
 )
 ```
 
@@ -198,8 +208,8 @@ from pydantic_ai_skills import SkillScript
 
 script = SkillScript(
     name="my_script",
-    path=Path("./skills/my-skill/scripts/my_script.py"),
-    skill_name="my-skill"
+    description="Runs an analysis",
+    skill_name="my-skill",
 )
 ```
 

--- a/docs/creating-skills.md
+++ b/docs/creating-skills.md
@@ -293,7 +293,7 @@ from dataclasses import dataclass
 
 from fastapi import Request
 from pydantic_ai import Agent
-from pydantic_ai.toolsets.skills import LocalSkillScriptExecutor, SkillsDirectory, SkillsToolset
+from pydantic_ai_skills import LocalSkillScriptExecutor, SkillsDirectory, SkillsToolset
 
 
 @dataclass

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -14,7 +14,7 @@ Best for:
 
 ```python
 from pydantic_ai import Agent
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 # File-based approach: organize skills in directory structure
 # ./skills/
@@ -41,7 +41,7 @@ Best for:
 
 ```python
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 class MyDeps:
     database: Database
@@ -72,7 +72,7 @@ agent = Agent(
 Combine both for flexibility:
 
 ```python
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 # Mix file-based and programmatic skills
 toolset = SkillsToolset(
@@ -103,7 +103,7 @@ agent = Agent(model='openai:gpt-4o', toolsets=[toolset])
 Use for reference documentation and fixed content:
 
 ```python
-from pydantic_ai.toolsets.skills import Skill, SkillResource
+from pydantic_ai_skills import Skill, SkillResource
 
 skill = Skill(
     name='reference-skill',
@@ -147,7 +147,7 @@ Use for resources that depend on runtime state:
 ```python
 from typing import TypedDict
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 class MyDeps(TypedDict):
     database: Database
@@ -181,7 +181,7 @@ async def get_tables(ctx: RunContext[MyDeps]) -> str:
 Resources can accept parameters for dynamic content:
 
 ```python
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 skills = SkillsToolset()
 
@@ -520,7 +520,7 @@ Use TypedDict for clear dependency contracts:
 ```python
 from typing import TypedDict
 from pydantic_ai import Agent, RunContext
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 class MyDeps(TypedDict):
     """Dependencies available to skills."""
@@ -589,7 +589,7 @@ async def get_cached_status(ctx: RunContext[MyDeps]) -> str:
 Defer expensive setup:
 
 ```python
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 skills = SkillsToolset()
 
@@ -614,7 +614,7 @@ async def get_expensive_resource(ctx: RunContext[MyDeps]) -> str:
 ```python
 import pytest
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import Skill, SkillsToolset
+from pydantic_ai_skills import Skill, SkillsToolset
 
 class MockDeps:
     def __init__(self):
@@ -659,7 +659,7 @@ def test_skill_in_toolset():
 ```python
 import pytest
 from pydantic_ai import Agent
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 @pytest.fixture
 def test_skills():

--- a/docs/programmatic-skills.md
+++ b/docs/programmatic-skills.md
@@ -27,7 +27,7 @@ Programmatic skills let you:
 ## Creating a Basic Programmatic Skill
 
 ```python
-from pydantic_ai.toolsets.skills import Skill, SkillResource, SkillsToolset
+from pydantic_ai_skills import Skill, SkillResource, SkillsToolset
 
 # Create a skill with static resources
 my_skill = Skill(
@@ -83,7 +83,7 @@ Use the `@skill.resource` decorator to create resources that generate content dy
 
 ```python
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import Skill
+from pydantic_ai_skills import Skill
 
 my_skill = Skill(
     name='database-skill',
@@ -116,7 +116,7 @@ Use the `@skill.script` decorator to create executable scripts:
 
 ```python
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import Skill
+from pydantic_ai_skills import Skill
 
 my_skill = Skill(
     name='data-processor',
@@ -161,7 +161,7 @@ from dataclasses import dataclass, field
 
 import datasets
 from pydantic_ai import Agent, RunContext
-from pydantic_ai.toolsets.skills import Skill, SkillResource, SkillsToolset
+from pydantic_ai_skills import Skill, SkillResource, SkillsToolset
 
 @dataclass
 class AnalystDeps:
@@ -325,7 +325,7 @@ print(result.output)
 You can combine both approaches in the same toolset:
 
 ```python
-from pydantic_ai.toolsets.skills import Skill, SkillsToolset
+from pydantic_ai_skills import Skill, SkillsToolset
 
 # Programmatic skill
 my_skill = Skill(
@@ -363,7 +363,7 @@ Programmatic skills leverage Pydantic AI's type-safe function schema generation:
 
 ```python
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import Skill
+from pydantic_ai_skills import Skill
 
 my_skill = Skill(name='typed-skill', description='Type-safe skill', content='...')
 
@@ -420,7 +420,7 @@ For concise skill definition directly on a `SkillsToolset`, use the `@toolset.sk
 
 ```python
 from pydantic_ai import Agent, RunContext
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 skills = SkillsToolset()
 
@@ -461,7 +461,7 @@ See [Advanced Features](advanced.md) for full decorator documentation.
 Combine file-based and programmatic skills in a single toolset:
 
 ```python
-from pydantic_ai.toolsets.skills import SkillsToolset
+from pydantic_ai_skills import SkillsToolset
 
 skills = SkillsToolset(directories=['./skills'])
 
@@ -555,7 +555,7 @@ Test resources and scripts independently:
 ```python
 import pytest
 from pydantic_ai import RunContext
-from pydantic_ai.toolsets.skills import Skill
+from pydantic_ai_skills import Skill
 
 @pytest.fixture
 def skill():

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -208,7 +208,7 @@ Create skills directly in Python code for dynamic capabilities:
 
 ```python
 from pydantic_ai import Agent, RunContext
-from pydantic_ai.toolsets.skills import Skill, SkillsToolset
+from pydantic_ai_skills import Skill, SkillsToolset
 
 # Create a programmatic skill
 my_skill = Skill(

--- a/pydantic_ai_skills/capability.py
+++ b/pydantic_ai_skills/capability.py
@@ -34,6 +34,19 @@ class SkillsCapability(AbstractCapability[Any]):
             capabilities=[SkillsCapability(directories=['./skills'])],
         )
         ```
+
+    Set `defer_loading=True` (with a stable `id`) to hide the skills tools and
+    instructions behind the agent's `load_capability` tool until the model
+    explicitly loads them:
+
+        ```python
+        agent = Agent(
+            model='openai:gpt-5.2',
+            capabilities=[
+                SkillsCapability(id='skills', directories=['./skills'], defer_loading=True),
+            ],
+        )
+        ```
     """
 
     def __init__(
@@ -48,6 +61,8 @@ class SkillsCapability(AbstractCapability[Any]):
         instruction_template: str | None = None,
         exclude_tools: set[str] | list[str] | None = None,
         auto_reload: bool = False,
+        description: str | None = None,
+        defer_loading: bool = False,
     ) -> None:
         """Initialize a skills capability.
 
@@ -57,11 +72,25 @@ class SkillsCapability(AbstractCapability[Any]):
             registries: Remote registries to discover.
             validate: Validate skill structure during discovery.
             max_depth: Maximum discovery depth.
-            id: Optional toolset id.
+            id: Stable identifier shared by the capability and its toolset. Required when
+                ``defer_loading`` is True so message history can identify the capability.
             instruction_template: Optional custom instructions template.
             exclude_tools: Tool names to exclude.
             auto_reload: Re-scan directories before each run.
+            description: Optional catalog description surfaced to the model when
+                ``defer_loading`` is True. Defaults to a summary of the available skills.
+            defer_loading: If True, the skills tools and instructions stay hidden until the
+                model loads this capability via the agent's ``load_capability`` tool.
+
+        Raises:
+            ValueError: If ``defer_loading`` is True but no ``id`` is provided.
         """
+        if defer_loading and id is None:
+            raise ValueError("SkillsCapability requires a stable 'id' when defer_loading=True.")
+
+        self.id = id
+        self.description = description
+        self.defer_loading = defer_loading
         self._toolset = SkillsToolset(
             skills=skills,
             directories=directories,
@@ -81,6 +110,19 @@ class SkillsCapability(AbstractCapability[Any]):
     def get_instructions(self) -> AgentInstructions[AgentDepsT] | None:
         """Return None — instructions are pulled natively from the toolset by the agent."""
         return None
+
+    def get_description(self) -> str | None:
+        """Return the catalog description shown when this capability is deferred.
+
+        Falls back to a summary of the available skill names when no explicit
+        ``description`` was provided.
+        """
+        if self.description is not None:
+            return self.description
+        names = sorted(self._toolset.skills)
+        if not names:
+            return None
+        return 'Provides specialized skills: ' + ', '.join(names) + '.'
 
     @property
     def toolset(self) -> SkillsToolset:

--- a/pydantic_ai_skills/directory.py
+++ b/pydantic_ai_skills/directory.py
@@ -270,13 +270,13 @@ class SkillsDirectory:
             source = SkillsDirectory(path="./skills")
 
             # With custom executor
-            from pydantic_ai.toolsets.skills import LocalSkillScriptExecutor
+            from pydantic_ai_skills import LocalSkillScriptExecutor
 
             executor = LocalSkillScriptExecutor(timeout=60)
             source = SkillsDirectory(path="./skills", script_executor=executor)
 
             # With callable executor
-            from pydantic_ai.toolsets.skills import CallableSkillScriptExecutor
+            from pydantic_ai_skills import CallableSkillScriptExecutor
 
             async def my_executor(script, args=None, skill_uri=None):
                 return f"Executed {script.name}"

--- a/pydantic_ai_skills/local.py
+++ b/pydantic_ai_skills/local.py
@@ -444,7 +444,7 @@ class CallableSkillScriptExecutor:
 
     Example:
         ```python
-        from pydantic_ai.toolsets.skills import CallableSkillScriptExecutor, SkillsDirectory
+        from pydantic_ai_skills import CallableSkillScriptExecutor, SkillsDirectory
 
         async def my_executor(script, args=None):
             # Custom execution logic - script.uri contains the file path

--- a/pydantic_ai_skills/toolset.py
+++ b/pydantic_ai_skills/toolset.py
@@ -20,9 +20,8 @@ from pathlib import Path
 from typing import Annotated, Any
 
 from pydantic import BeforeValidator
-from pydantic_ai import ModelRetry
+from pydantic_ai import ModelRetry, RunContext
 from pydantic_ai._griffe import doc_descriptions
-from pydantic_ai._run_context import RunContext
 from pydantic_ai.toolsets import FunctionToolset
 
 from .directory import SkillsDirectory
@@ -122,12 +121,11 @@ class SkillsToolset(FunctionToolset[Any]):
         )
 
         # Programmatic skills
-        from pydantic_ai.toolsets.skills import Skill, SkillMetadata
+        from pydantic_ai_skills import Skill
 
         custom_skill = Skill(
             name="my-skill",
-            uri="./custom",
-            metadata=SkillMetadata(name="my-skill", description="Custom skill"),
+            description="Custom skill",
             content="Instructions here",
         )
         agent = Agent(
@@ -145,7 +143,7 @@ class SkillsToolset(FunctionToolset[Any]):
         )
 
         # Using SkillsDirectory instances directly
-        from pydantic_ai.toolsets.skills import SkillsDirectory
+        from pydantic_ai_skills import SkillsDirectory
 
         dir1 = SkillsDirectory(path="./skills")
         agent = Agent(
@@ -760,7 +758,7 @@ class SkillsToolset(FunctionToolset[Any]):
         Example:
             ```python
             from pydantic_ai import RunContext
-            from pydantic_ai.toolsets.skills import SkillsToolset
+            from pydantic_ai_skills import SkillsToolset
 
             skills = SkillsToolset()
 

--- a/pydantic_ai_skills/types.py
+++ b/pydantic_ai_skills/types.py
@@ -190,7 +190,7 @@ class Skill:
     Example - Programmatic skill with decorators:
         ```python
         from pydantic_ai import RunContext
-        from pydantic_ai.toolsets.skills import Skill, SkillResource
+        from pydantic_ai_skills import Skill, SkillResource
 
         # Create a skill (uri is optional and only for file-based skills)
         my_skill = Skill(
@@ -491,7 +491,7 @@ class SkillWrapper(Generic[DepsT]):
         ```python
         from dataclasses import dataclass
         from pydantic_ai import RunContext
-        from pydantic_ai.toolsets.skills import SkillsToolset
+        from pydantic_ai_skills import SkillsToolset
 
         @dataclass
         class MyDeps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "anyio>=4.0.0",
-    "pydantic-ai-slim>=1.74",
+    "pydantic-ai-slim>=1.105",
     "pyyaml>=6.0",
 ]
 

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -83,3 +83,58 @@ async def test_skills_capability_get_instructions_returns_none() -> None:
     """get_instructions returns None — agent extracts instructions natively from the toolset."""
     capability = SkillsCapability(skills=[])
     assert capability.get_instructions() is None
+
+
+def test_skills_capability_defaults_not_deferred() -> None:
+    """By default the capability is not deferred and has no id/description."""
+    capability = SkillsCapability(skills=[])
+    assert capability.defer_loading is False
+    assert capability.id is None
+    assert capability.description is None
+
+
+def test_skills_capability_defer_loading_sets_attributes() -> None:
+    """defer_loading should set the capability id/description/defer_loading attributes."""
+    capability = SkillsCapability(skills=[], id='skills', defer_loading=True)
+    assert capability.defer_loading is True
+    assert capability.id == 'skills'
+
+
+def test_skills_capability_defer_loading_requires_id() -> None:
+    """defer_loading without an id should raise a clear error."""
+    with pytest.raises(ValueError, match="requires a stable 'id'"):
+        SkillsCapability(skills=[], defer_loading=True)
+
+
+def _write_skill(directory: Path, name: str) -> None:
+    skill_dir = directory / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / 'SKILL.md').write_text(
+        f'---\nname: {name}\ndescription: The {name} skill.\n---\n# {name}\nBody.\n',
+        encoding='utf-8',
+    )
+
+
+def test_skills_capability_get_description_summarizes_skills(tmp_path: Path) -> None:
+    """get_description should summarize the available skill names when none is given."""
+    _write_skill(tmp_path, 'alpha')
+    _write_skill(tmp_path, 'beta')
+
+    capability = SkillsCapability(id='skills', directories=[tmp_path], defer_loading=True)
+    assert capability.get_description() == 'Provides specialized skills: alpha, beta.'
+
+
+def test_skills_capability_get_description_prefers_explicit(tmp_path: Path) -> None:
+    """An explicit description should override the generated summary."""
+    _write_skill(tmp_path, 'alpha')
+
+    capability = SkillsCapability(
+        id='skills', directories=[tmp_path], defer_loading=True, description='Custom catalog text.'
+    )
+    assert capability.get_description() == 'Custom catalog text.'
+
+
+def test_skills_capability_get_description_none_when_no_skills() -> None:
+    """get_description should return None when there are no skills and no description."""
+    capability = SkillsCapability(skills=[])
+    assert capability.get_description() is None

--- a/tests/test_pydantic_ai_compat.py
+++ b/tests/test_pydantic_ai_compat.py
@@ -1,0 +1,22 @@
+"""Compatibility guards for the pydantic-ai internals this package relies on.
+
+These symbols live in private (`_`-prefixed) pydantic-ai modules. They are not part
+of the public API, so a future pydantic-ai release may move or remove them. This test
+exists so such a break fails loudly here (and in CI) with a clear pointer, rather than
+surfacing as an obscure error deep inside a skill run.
+"""
+
+from __future__ import annotations
+
+
+def test_private_pydantic_ai_imports_available() -> None:
+    """The private pydantic-ai symbols used across this package must import."""
+    from pydantic_ai._function_schema import FunctionSchema, function_schema  # noqa: F401
+    from pydantic_ai._griffe import doc_descriptions  # noqa: F401
+    from pydantic_ai._utils import is_async_callable, run_in_executor  # noqa: F401
+    from pydantic_ai.tools import GenerateToolJsonSchema  # noqa: F401
+
+
+def test_public_run_context_import() -> None:
+    """RunContext is imported from the public pydantic_ai namespace."""
+    from pydantic_ai import RunContext  # noqa: F401


### PR DESCRIPTION
## What & why

Pydantic AI shipped **v2.0.0** (the 1.74 → 2.0.0 line introduced a capabilities-first / harness design). The package was already functionally compatible, but it did not expose the new v2 surface and carried a few latent defects. This PR adopts the relevant v2 features and fixes those issues.

Jira: [DEV-1215](https://douglastrajano.atlassian.net/browse/DEV-1215)

## Changes

- **Deferred loading for `SkillsCapability`** — expose `defer_loading`, `id`, and `description`; set the underlying `AbstractCapability` fields; raise a clear error when `defer_loading=True` without a stable `id`; override `get_description()` to summarize available skills (overridable via `description`). Documented in `docs/concepts.md`.
- **De-risk private imports** — replace private `pydantic_ai._run_context.RunContext` with the public `pydantic_ai.RunContext`; add `tests/test_pydantic_ai_compat.py` guarding the remaining unavoidable internals (`_griffe`, `_function_schema`, `_utils`) so a future pydantic-ai bump fails loudly in CI.
- **Fix broken examples** — replace the non-existent `from pydantic_ai.toolsets.skills import ...` module path (44 references across source docstrings and docs) with `pydantic_ai_skills`, and fix two examples referencing a non-existent `SkillMetadata` type / wrong `Skill(...)` shape.
- **Dependency floor** — raise to `pydantic-ai-slim>=1.105` (on-demand / deferred capability loading landed in the 1.105 line). Package version bump intentionally left to the release process.
- **CI version matrix** — test against pydantic-ai `1.105.0`, `2.0.0`, and `latest`; coverage / PR-metadata artifacts gated to the deterministic Python 3.12 + 2.0.0 job.

## Testing

- Full suite passes against both **1.105.0** and **2.0.0** locally (440 tests, +8 new); `ruff check` and `ruff format --check` clean.
- No remaining references to `pydantic_ai.toolsets.skills`, `SkillMetadata`, or `_run_context`.

## Reviewer notes

- The `latest` CI entry is intentionally non-deterministic — it gives early warning of upstream breakage. Coverage reporting is gated to the pinned 2.0.0 job so it stays reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEV-1215]: https://douglastrajano.atlassian.net/browse/DEV-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ