### PR TITLE
feat: support agent specs for SkillsCapability

### DIFF
--- a/docs/api/capability.md
+++ b/docs/api/capability.md
@@ -10,8 +10,11 @@ This is the preferred integration path. Use it when your agent uses `capabilitie
       heading_level: 2
       members:
         - __init__
+        - from_spec
+        - get_serialization_name
         - get_toolset
         - get_instructions
+        - get_description
         - toolset
 
 ## Constructor Parameters
@@ -54,3 +57,32 @@ agent = Agent(
     ],
 )
 ```
+
+## Agent specs
+
+`SkillsCapability` can be used in declarative agent specs loaded with `Agent.from_spec`
+or `Agent.from_file`. Register the class via `custom_capability_types` so the spec loader
+can resolve the `SkillsCapability` key:
+
+```yaml
+# agent.yaml
+model: openai:gpt-5.2
+capabilities:
+  - SkillsCapability:
+      directories: ['./skills']
+      id: skills
+      defer_loading: true
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_skills import SkillsCapability
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[SkillsCapability])
+```
+
+Only serializable arguments are spec-expressible: `directories` (as path strings),
+`validate`, `max_depth`, `id`, `instruction_template`, `exclude_tools`, `auto_reload`,
+`description`, and `defer_loading`. Programmatic `skills`, `registries`, and
+`SkillsDirectory` instances are not representable in a spec — construct the capability in
+Python for those. See [`from_spec`][pydantic_ai_skills.capability.SkillsCapability.from_spec].

--- a/pydantic_ai_skills/capability.py
+++ b/pydantic_ai_skills/capability.py
@@ -6,6 +6,7 @@ the preferred integration path for Pydantic AI users via the `capabilities=[...]
 
 from __future__ import annotations
 
+from dataclasses import KW_ONLY, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,7 @@ from .toolset import SkillsToolset
 from .types import Skill
 
 
+@dataclass
 class SkillsCapability(AbstractCapability[Any]):
     """Capability wrapper for `SkillsToolset`.
 
@@ -47,60 +49,124 @@ class SkillsCapability(AbstractCapability[Any]):
             ],
         )
         ```
+
+    The capability is usable in declarative agent specs (`Agent.from_spec` /
+    `Agent.from_file`) by passing it via `custom_capability_types`:
+
+        ```yaml
+        capabilities:
+          - SkillsCapability:
+              directories: ['./skills']
+              defer_loading: true
+              id: skills
+        ```
+
+        ```python
+        agent = Agent.from_file('agent.yaml', custom_capability_types=[SkillsCapability])
+        ```
+
+    Only serializable arguments are spec-expressible (see
+    [`from_spec`][pydantic_ai_skills.SkillsCapability.from_spec]); programmatic
+    `skills`, `registries`, and `SkillsDirectory` instances require Python construction.
     """
 
-    def __init__(
-        self,
-        *,
-        skills: list[Skill] | None = None,
-        directories: list[str | Path | SkillsDirectory] | None = None,
-        registries: list[SkillRegistry] | None = None,
-        validate: bool = True,
-        max_depth: int | None = 3,
-        id: str | None = None,
-        instruction_template: str | None = None,
-        exclude_tools: set[str] | list[str] | None = None,
-        auto_reload: bool = False,
-        description: str | None = None,
-        defer_loading: bool = False,
-    ) -> None:
-        """Initialize a skills capability.
+    _: KW_ONLY
 
-        Args:
-            skills: Pre-loaded skills.
-            directories: Skill directories to discover.
-            registries: Remote registries to discover.
-            validate: Validate skill structure during discovery.
-            max_depth: Maximum discovery depth.
-            id: Stable identifier shared by the capability and its toolset. Required when
-                ``defer_loading`` is True so message history can identify the capability.
-            instruction_template: Optional custom instructions template.
-            exclude_tools: Tool names to exclude.
-            auto_reload: Re-scan directories before each run.
-            description: Optional catalog description surfaced to the model when
-                ``defer_loading`` is True. Defaults to a summary of the available skills.
-            defer_loading: If True, the skills tools and instructions stay hidden until the
-                model loads this capability via the agent's ``load_capability`` tool.
+    skills: list[Skill] | None = None
+    """Pre-loaded skills."""
+
+    directories: list[str | Path | SkillsDirectory] | None = None
+    """Skill directories to discover."""
+
+    registries: list[SkillRegistry] | None = None
+    """Remote registries to discover."""
+
+    validate: bool = True
+    """Validate skill structure during discovery."""
+
+    max_depth: int | None = 3
+    """Maximum discovery depth."""
+
+    instruction_template: str | None = None
+    """Optional custom instructions template."""
+
+    exclude_tools: set[str] | list[str] | None = None
+    """Tool names to exclude."""
+
+    auto_reload: bool = False
+    """Re-scan directories before each run."""
+
+    _toolset: SkillsToolset = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Validate deferred configuration and build the underlying toolset.
 
         Raises:
             ValueError: If ``defer_loading`` is True but no ``id`` is provided.
         """
-        if defer_loading and id is None:
+        if self.defer_loading and self.id is None:
             raise ValueError("SkillsCapability requires a stable 'id' when defer_loading=True.")
 
-        self.id = id
-        self.description = description
-        self.defer_loading = defer_loading
         self._toolset = SkillsToolset(
-            skills=skills,
-            directories=directories,
-            registries=registries,
+            skills=self.skills,
+            directories=self.directories,
+            registries=self.registries,
+            validate=self.validate,
+            max_depth=self.max_depth,
+            id=self.id,
+            instruction_template=self.instruction_template,
+            exclude_tools=self.exclude_tools,
+            auto_reload=self.auto_reload,
+        )
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        """Return the name used to reference this capability in agent specs."""
+        return 'SkillsCapability'
+
+    @classmethod
+    def from_spec(
+        cls,
+        *,
+        directories: list[str] | None = None,
+        validate: bool = True,
+        max_depth: int | None = 3,
+        id: str | None = None,
+        instruction_template: str | None = None,
+        exclude_tools: list[str] | None = None,
+        auto_reload: bool = False,
+        description: str | None = None,
+        defer_loading: bool = False,
+    ) -> SkillsCapability:
+        """Create from a YAML/JSON agent spec.
+
+        Only serializable arguments are supported. Programmatic `skills`, `registries`,
+        and `SkillsDirectory` instances cannot be expressed in a spec; construct the
+        capability in Python for those.
+
+        Args:
+            directories: Skill directories to discover, as path strings.
+            validate: Validate skill structure during discovery.
+            max_depth: Maximum discovery depth.
+            id: Stable identifier shared by the capability and its toolset. Required when
+                ``defer_loading`` is True.
+            instruction_template: Optional custom instructions template.
+            exclude_tools: Tool names to exclude.
+            auto_reload: Re-scan directories before each run.
+            description: Optional catalog description surfaced when ``defer_loading`` is True.
+            defer_loading: If True, the skills tools and instructions stay hidden until the
+                model loads this capability via the agent's ``load_capability`` tool.
+        """
+        return cls(
+            directories=list(directories) if directories is not None else None,
             validate=validate,
             max_depth=max_depth,
             id=id,
             instruction_template=instruction_template,
             exclude_tools=exclude_tools,
             auto_reload=auto_reload,
+            description=description,
+            defer_loading=defer_loading,
         )
 
     def get_toolset(self) -> SkillsToolset | None:

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 
 import pytest
@@ -145,7 +146,7 @@ def test_skills_capability_get_description_none_when_no_skills() -> None:
 
 def test_skills_capability_is_dataclass() -> None:
     """SkillsCapability must be a dataclass so it can register as a custom capability type."""
-    assert '__dataclass_fields__' in SkillsCapability.__dict__
+    assert dataclasses.is_dataclass(SkillsCapability)
 
 
 def test_skills_capability_rejects_positional_args() -> None:
@@ -202,7 +203,13 @@ def test_skills_capability_loaded_from_agent_spec(tmp_path: Path) -> None:
         ],
     }
     agent = Agent.from_spec(spec, custom_capability_types=[SkillsCapability])
-    assert isinstance(agent, Agent)
+
+    leaves: list[object] = []
+    agent._root_capability.apply(leaves.append)
+    skills_caps = [c for c in leaves if isinstance(c, SkillsCapability)]
+    assert len(skills_caps) == 1
+    assert skills_caps[0].id == 'skills'
+    assert isinstance(skills_caps[0].get_toolset(), SkillsToolset)
 
 
 def test_skills_capability_spec_schema_generation() -> None:

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -138,3 +138,76 @@ def test_skills_capability_get_description_none_when_no_skills() -> None:
     """get_description should return None when there are no skills and no description."""
     capability = SkillsCapability(skills=[])
     assert capability.get_description() is None
+
+
+# --- Agent spec support ---
+
+
+def test_skills_capability_is_dataclass() -> None:
+    """SkillsCapability must be a dataclass so it can register as a custom capability type."""
+    assert '__dataclass_fields__' in SkillsCapability.__dict__
+
+
+def test_skills_capability_rejects_positional_args() -> None:
+    """All constructor arguments are keyword-only."""
+    with pytest.raises(TypeError):
+        SkillsCapability([], [])  # type: ignore[misc]
+
+
+def test_skills_capability_serialization_name() -> None:
+    """The serialization name is the stable spec key."""
+    assert SkillsCapability.get_serialization_name() == 'SkillsCapability'
+
+
+def test_skills_capability_registers_in_capability_registry() -> None:
+    """The class must be accepted by the pydantic-ai capability registry builder."""
+    from pydantic_ai.agent.spec import get_capability_registry
+
+    registry = get_capability_registry([SkillsCapability])
+    assert registry.get('SkillsCapability') is SkillsCapability
+
+
+def test_skills_capability_from_spec_builds_toolset(tmp_path: Path) -> None:
+    """from_spec should construct a working capability from serializable arguments."""
+    _write_skill(tmp_path, 'alpha')
+
+    capability = SkillsCapability.from_spec(
+        directories=[str(tmp_path)],
+        id='skills',
+        defer_loading=True,
+        description='Catalog text.',
+    )
+    assert isinstance(capability.get_toolset(), SkillsToolset)
+    assert capability.id == 'skills'
+    assert capability.defer_loading is True
+    assert capability.get_description() == 'Catalog text.'
+
+
+def test_skills_capability_from_spec_defer_loading_requires_id() -> None:
+    """from_spec should enforce the same defer_loading/id invariant as the constructor."""
+    with pytest.raises(ValueError, match="requires a stable 'id'"):
+        SkillsCapability.from_spec(directories=['./skills'], defer_loading=True)
+
+
+def test_skills_capability_loaded_from_agent_spec(tmp_path: Path) -> None:
+    """An agent built from a dict spec should expose the skills toolset."""
+    from pydantic_ai import Agent
+
+    _write_skill(tmp_path, 'alpha')
+
+    spec = {
+        'model': 'test',
+        'capabilities': [
+            {'SkillsCapability': {'directories': [str(tmp_path)], 'id': 'skills', 'defer_loading': True}},
+        ],
+    }
+    agent = Agent.from_spec(spec, custom_capability_types=[SkillsCapability])
+    assert isinstance(agent, Agent)
+
+
+def test_skills_capability_spec_schema_generation() -> None:
+    """JSON schema generation including SkillsCapability should succeed."""
+    from pydantic_ai.agent.spec import AgentSpec
+
+    schema = AgentSpec.model_json_schema_with_capabilities([SkillsCapability])
+    assert 'SkillsCapability' in str(schema)


### PR DESCRIPTION
## Summary

Makes `SkillsCapability` usable in declarative Pydantic AI agent specs (`Agent.from_spec` / `Agent.from_file` with `custom_capability_types=[SkillsCapability]`), per the [extensibility guide](https://pydantic.dev/docs/ai/guides/extensibility/index.md).

**Problem:** `SkillsCapability` extends `AbstractCapability` but the pydantic-ai spec loader (`pydantic_ai/agent/spec.py`) rejects any custom capability type that is not a `@dataclass`. Registry construction failed before serialization was even considered:

```
get_capability_registry([SkillsCapability])
→ ValueError: All custom capability classes must be decorated with `@dataclass`
```

Tracked in [DEV-1216](https://douglastrajano.atlassian.net/browse/DEV-1216).

## What changed

- **`@dataclass` conversion** — `SkillsCapability` is now a `@dataclass` mirroring the base `AbstractCapability` (`KW_ONLY` fields, inherited `id`/`description`/`defer_loading`). Toolset construction and the `defer_loading`-requires-`id` check moved into `__post_init__`; `_toolset` is a non-init field. Public API is unchanged — all args stay keyword-only.
- **Spec hooks** — added a serializable-only `from_spec()` classmethod and an explicit `get_serialization_name()`. Programmatic `skills` / `registries` / `SkillsDirectory` objects remain Python-only (not spec-expressible).
- **Tests** — 8 new in `tests/test_capability.py`: dataclass check, keyword-only enforcement, serialization name, registry build, `from_spec` round-trip + id-validation, full `Agent.from_spec` load, and JSON-schema generation.
- **Docs** — new "Agent specs" section in `docs/api/capability.md` with a YAML + `custom_capability_types` example.

## Reviewer notes

- `get_serialization_name()` already worked via the base default (`'SkillsCapability'`); it's now explicit for stability.
- The keyword-only API is preserved via a `_: KW_ONLY` sentinel in the subclass — positional construction now raises `TypeError` (covered by a test).
- Behavior stays delegated to `SkillsToolset` for parity.

## Verification

- `get_capability_registry([SkillsCapability])` succeeds; an agent builds from a dict/YAML spec; schema generation is clean.
- `ruff check` / `ruff format --check` clean; mypy + pre-commit hooks pass.
- Full suite: **448 passed** (440 + 8 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEV-1216]: https://douglastrajano.atlassian.net/browse/DEV-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ