### PR TITLE
feat: discover all readable text files as skill resources (#54)

### DIFF
--- a/docs/creating-skills.md
+++ b/docs/creating-skills.md
@@ -629,7 +629,7 @@ read_skill_resource(
 )
 ```
 
-### What Counts as a Resource
+### Resource Discovery
 
 Discovery registers **every readable text file** in the skill folder (any subdirectory,
 any extension) as a resource — so `.sql`, `.toml`, `.jinja`, and friends work with no

--- a/docs/creating-skills.md
+++ b/docs/creating-skills.md
@@ -629,6 +629,34 @@ read_skill_resource(
 )
 ```
 
+### What Counts as a Resource
+
+Discovery registers **every readable text file** in the skill folder (any subdirectory,
+any extension) as a resource — so `.sql`, `.toml`, `.jinja`, and friends work with no
+configuration. The following are automatically skipped:
+
+- **`SKILL.md`** itself.
+- **Binary files** — anything that does not decode as UTF-8 (images, PDFs, fonts, compiled artifacts). Discovery decodes a bounded prefix of each file (the same UTF-8 the loader uses), so binaries are filtered cheaply without reading whole files.
+- **Scripts** — files discovered as executable scripts are never also resources.
+- **Noise** — the default exclude globs: `__pycache__`, `*.pyc`, `*.pyo`, `.DS_Store`, `.git`.
+
+To exclude more files, pass `exclude_resources` — glob patterns that **extend** the
+defaults (they never replace them, so noise stays excluded):
+
+```python
+from pydantic_ai_skills import SkillsToolset
+
+toolset = SkillsToolset(
+    directories=["./skills"],
+    exclude_resources=["*.tmp", "drafts/*"],  # in addition to the defaults
+)
+```
+
+A pattern matches a file when it matches the full skill-relative path (e.g. `drafts/*`)
+or any single path component (e.g. `*.tmp`, `secrets`). The same parameter is available
+on `SkillsDirectory`, `discover_skills`, `Skill.from_file`, and `SkillsCapability`. The
+default patterns are exported as `pydantic_ai_skills.directory.DEFAULT_RESOURCE_EXCLUDES`.
+
 ## Organizing Multiple Skills
 
 ### Flat Structure

--- a/pydantic_ai_skills/capability.py
+++ b/pydantic_ai_skills/capability.py
@@ -87,6 +87,9 @@ class SkillsCapability(AbstractCapability[Any]):
     max_depth: int | None = 3
     """Maximum discovery depth."""
 
+    exclude_resources: list[str] | None = None
+    """Extra glob patterns to exclude from resource discovery, in addition to the built-in defaults."""
+
     instruction_template: str | None = None
     """Optional custom instructions template."""
 
@@ -113,6 +116,7 @@ class SkillsCapability(AbstractCapability[Any]):
             registries=self.registries,
             validate=self.validate,
             max_depth=self.max_depth,
+            exclude_resources=self.exclude_resources,
             id=self.id,
             instruction_template=self.instruction_template,
             exclude_tools=self.exclude_tools,
@@ -131,6 +135,7 @@ class SkillsCapability(AbstractCapability[Any]):
         directories: list[str] | None = None,
         validate: bool = True,
         max_depth: int | None = 3,
+        exclude_resources: list[str] | None = None,
         id: str | None = None,
         instruction_template: str | None = None,
         exclude_tools: list[str] | None = None,
@@ -148,6 +153,8 @@ class SkillsCapability(AbstractCapability[Any]):
             directories: Skill directories to discover, as path strings.
             validate: Validate skill structure during discovery.
             max_depth: Maximum discovery depth.
+            exclude_resources: Extra glob patterns to exclude from resource discovery, in addition
+                to the built-in defaults (``__pycache__``, ``*.pyc``, ``.DS_Store`` …).
             id: Stable identifier shared by the capability and its toolset. Required when
                 ``defer_loading`` is True.
             instruction_template: Optional custom instructions template.
@@ -161,6 +168,7 @@ class SkillsCapability(AbstractCapability[Any]):
             directories=list(directories) if directories is not None else None,
             validate=validate,
             max_depth=max_depth,
+            exclude_resources=list(exclude_resources) if exclude_resources is not None else None,
             id=id,
             instruction_template=instruction_template,
             exclude_tools=exclude_tools,

--- a/pydantic_ai_skills/directory.py
+++ b/pydantic_ai_skills/directory.py
@@ -9,8 +9,11 @@ internal helper functions for skill validation, metadata parsing, and resource/s
 
 from __future__ import annotations
 
+import codecs
 import os
 import warnings
+from collections.abc import Iterable
+from fnmatch import fnmatch
 from pathlib import Path
 
 from ._parsing import parse_skill_md, validate_skill_metadata
@@ -25,6 +28,66 @@ from .types import Skill, SkillResource, SkillScript
 _SUPPORTED_SCRIPT_EXTENSIONS = {'.py', '.sh', '.bash', '.zsh', '.fish', '.ps1', '.bat', '.cmd'}
 _WINDOWS_EXECUTABLE_EXTENSIONS = {'.exe', '.bat', '.cmd', '.com', '.ps1'}
 _IGNORED_SCRIPT_NAMES = {'__init__.py', 'SKILL.md'}
+
+#: Glob patterns always excluded from resource discovery. User-provided
+#: ``exclude_resources`` patterns extend (do not replace) this set.
+DEFAULT_RESOURCE_EXCLUDES: tuple[str, ...] = ('__pycache__', '*.pyc', '*.pyo', '.DS_Store', '.git')
+
+_TEXT_SNIFF_BYTES = 65536
+
+
+def _resolve_resource_excludes(exclude_resources: Iterable[str] | None) -> list[str]:
+    """Build the resource exclude patterns, extending the built-in defaults.
+
+    User-provided glob patterns are appended to :data:`DEFAULT_RESOURCE_EXCLUDES`,
+    so noise such as ``__pycache__`` and ``.DS_Store`` stays excluded even when a
+    caller supplies extra patterns.
+
+    Args:
+        exclude_resources: Extra glob patterns to exclude, or None for defaults only.
+
+    Returns:
+        List of glob patterns with the defaults first.
+    """
+    patterns = list(DEFAULT_RESOURCE_EXCLUDES)
+    if exclude_resources is not None:
+        patterns.extend(exclude_resources)
+    return patterns
+
+
+def _is_excluded(rel_path: Path, patterns: list[str]) -> bool:
+    """Return True if a skill-relative path matches any exclude glob.
+
+    A pattern matches when it matches the full posix-style relative path
+    (for path-scoped patterns like ``docs/*.tmp``) or any single path
+    component (for name patterns like ``__pycache__`` or ``*.pyc``).
+    """
+    posix = rel_path.as_posix()
+    for pattern in patterns:
+        if fnmatch(posix, pattern) or any(fnmatch(part, pattern) for part in rel_path.parts):
+            return True
+    return False
+
+
+def _is_text_file(path: Path) -> bool:
+    """Return True if a file reads as UTF-8 text (matching the resource loader).
+
+    The loader reads resources with ``read_text('utf-8')``, so a file only
+    qualifies as a resource if it decodes as UTF-8. To keep discovery cheap this
+    inspects at most the first ``_TEXT_SNIFF_BYTES`` bytes rather than the whole
+    file: binaries fail on the first invalid byte, and real text is text
+    throughout. Files that fit within the window are validated exactly (a
+    trailing multibyte character split by the window is not treated as invalid
+    for larger files). Unreadable files are treated as non-text and skipped.
+    """
+    try:
+        with path.open('rb') as handle:
+            prefix = handle.read(_TEXT_SNIFF_BYTES)
+            at_eof = handle.read(1) == b''
+        codecs.getincrementaldecoder('utf-8')().decode(prefix, final=at_eof)
+    except (UnicodeDecodeError, OSError):
+        return False
+    return True
 
 
 def _is_script_candidate(script_file: Path) -> bool:
@@ -68,50 +131,72 @@ def _resolve_script_path(script_file: Path, skill_folder_resolved: Path) -> Path
     return resolved_path
 
 
-__all__ = ['SkillsDirectory', 'discover_skills', 'parse_skill_md', 'validate_skill_metadata']
+__all__ = [
+    'DEFAULT_RESOURCE_EXCLUDES',
+    'SkillsDirectory',
+    'discover_skills',
+    'parse_skill_md',
+    'validate_skill_metadata',
+]
 
 
-def _discover_resources(skill_folder: Path) -> list[SkillResource]:
+def _discover_resources(
+    skill_folder: Path,
+    exclude_resources: Iterable[str] | None = None,
+    script_uris: set[str] | None = None,
+) -> list[SkillResource]:
     """Discover resource files in a skill folder.
 
-    Resources are text files other than SKILL.md in any subdirectory.
-    Supported: .md, .json, .yaml, .yml, .csv, .xml, .txt
+    Any UTF-8-readable text file other than SKILL.md, in any subdirectory, is a
+    resource. Binary files (anything that does not decode as UTF-8), files
+    discovered as scripts, and files matching an exclude glob are skipped.
 
     Security validates that resolved paths remain within skill_folder
     after symlink resolution to prevent traversal attacks.
 
     Args:
         skill_folder: Path to the skill directory.
+        exclude_resources: Extra glob patterns to exclude, in addition to the
+            built-in :data:`DEFAULT_RESOURCE_EXCLUDES`. None for defaults only.
+        script_uris: Resolved URIs of files already discovered as scripts, which
+            are excluded from resources so a file is never both.
 
     Returns:
         List of discovered SkillResource objects.
     """
     resources: list[SkillResource] = []
-    supported_extensions = ['.md', '.json', '.yaml', '.yml', '.csv', '.xml', '.txt']
+    exclude_patterns = _resolve_resource_excludes(exclude_resources)
+    script_uris = script_uris or set()
     skill_folder_resolved = skill_folder.resolve()
 
-    for extension in supported_extensions:
-        for resource_file in skill_folder.rglob(f'*{extension}'):
-            if resource_file.name.upper() != 'SKILL.MD':
-                resolved_path = resource_file.resolve()
-                try:
-                    resolved_path.relative_to(skill_folder_resolved)
-                except ValueError:
-                    warnings.warn(
-                        f"Resource '{resource_file}' resolves outside skill directory (symlink escape detected). Skipping.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                    continue
+    for resource_file in skill_folder.rglob('*'):
+        if not resource_file.is_file() or resource_file.name.upper() == 'SKILL.MD':
+            continue
 
-                rel_path = resource_file.relative_to(skill_folder)
-                name = rel_path.as_posix()
-                resources.append(
-                    create_file_based_resource(
-                        name=name,
-                        uri=str(resolved_path),
-                    )
-                )
+        rel_path = resource_file.relative_to(skill_folder)
+        if _is_excluded(rel_path, exclude_patterns):
+            continue
+
+        resolved_path = resource_file.resolve()
+        try:
+            resolved_path.relative_to(skill_folder_resolved)
+        except ValueError:
+            warnings.warn(
+                f"Resource '{resource_file}' resolves outside skill directory (symlink escape detected). Skipping.",
+                UserWarning,
+                stacklevel=2,
+            )
+            continue
+
+        if str(resolved_path) in script_uris or not _is_text_file(resource_file):
+            continue
+
+        resources.append(
+            create_file_based_resource(
+                name=rel_path.as_posix(),
+                uri=str(resolved_path),
+            )
+        )
 
     return resources
 
@@ -190,6 +275,7 @@ def discover_skills(
     validate: bool = True,
     max_depth: int | None = 3,
     script_executor: LocalSkillScriptExecutor | CallableSkillScriptExecutor | None = None,
+    exclude_resources: Iterable[str] | None = None,
 ) -> list[Skill]:
     """Discover skills from a filesystem directory.
 
@@ -202,6 +288,9 @@ def discover_skills(
         max_depth: Maximum depth to search for SKILL.md files. None for unlimited.
             Default is 3 levels deep to prevent performance issues with large trees.
         script_executor: Optional custom script executor for file-based scripts.
+        exclude_resources: Extra glob patterns to exclude from resource discovery, in
+            addition to the built-in :data:`DEFAULT_RESOURCE_EXCLUDES`. None for
+            defaults only.
 
     Returns:
         List of discovered Skill objects.
@@ -223,7 +312,12 @@ def discover_skills(
     skill_files = _find_skill_files(dir_path, max_depth)
     for skill_file in skill_files:
         try:
-            skill = Skill.from_file(skill_file, validate=validate, script_executor=executor)
+            skill = Skill.from_file(
+                skill_file,
+                validate=validate,
+                script_executor=executor,
+                exclude_resources=exclude_resources,
+            )
             skills.append(skill)
         except ValueError as ve:
             if validate:
@@ -253,6 +347,7 @@ class SkillsDirectory:
         validate: bool = True,
         max_depth: int | None = 3,
         script_executor: LocalSkillScriptExecutor | CallableSkillScriptExecutor | None = None,
+        exclude_resources: Iterable[str] | None = None,
     ) -> None:
         """Initialize the skills directory source.
 
@@ -263,6 +358,9 @@ class SkillsDirectory:
             script_executor: Optional custom script executor for file-based scripts.
                 Can be LocalSkillScriptExecutor or CallableSkillScriptExecutor.
                 If None, uses LocalSkillScriptExecutor with default settings.
+            exclude_resources: Extra glob patterns to exclude from resource discovery,
+                in addition to the built-in :data:`DEFAULT_RESOURCE_EXCLUDES`. None for
+                defaults only.
 
         Example:
             ```python
@@ -289,6 +387,7 @@ class SkillsDirectory:
         self._validate = validate
         self._max_depth = max_depth
         self._script_executor = script_executor or LocalSkillScriptExecutor()
+        self._exclude_resources = exclude_resources
 
         # Discover skills from directory
         self._skills: dict[str, Skill] = self.get_skills()
@@ -304,6 +403,7 @@ class SkillsDirectory:
             validate=self._validate,
             max_depth=self._max_depth,
             script_executor=self._script_executor,
+            exclude_resources=self._exclude_resources,
         )
 
         return {skill.uri: skill for skill in skills if skill.uri is not None}

--- a/pydantic_ai_skills/toolset.py
+++ b/pydantic_ai_skills/toolset.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from inspect import signature as get_signature
 from pathlib import Path
 from typing import Annotated, Any
@@ -162,6 +162,7 @@ class SkillsToolset(FunctionToolset[Any]):
         registries: list[SkillRegistry] | None = None,
         validate: bool = True,
         max_depth: int | None = 3,
+        exclude_resources: Iterable[str] | None = None,
         id: str | None = None,
         instruction_template: str | None = None,
         exclude_tools: set[str] | list[str] | None = None,
@@ -181,6 +182,10 @@ class SkillsToolset(FunctionToolset[Any]):
                 ``skills`` and ``directories``.
             validate: Validate skill structure during discovery (used when creating SkillsDirectory from str/Path).
             max_depth: Maximum depth for skill discovery (None for unlimited, used when creating SkillsDirectory from str/Path).
+            exclude_resources: Extra glob patterns to exclude from resource discovery, in addition to the
+                built-in defaults (``__pycache__``, ``*.pyc``, ``.DS_Store`` …). Used when creating
+                SkillsDirectory from str/Path. Any readable text file not excluded and not discovered as a
+                script becomes a resource. None for defaults only.
             id: Unique identifier for this toolset.
             instruction_template: Custom instruction template for skills system prompt.
                 Must include `{skills_list}` placeholder. If None, uses default template.
@@ -266,6 +271,7 @@ class SkillsToolset(FunctionToolset[Any]):
         self._registry_skills: dict[str, Skill] = {}  # Cache of registry-sourced skills
         self._validate = validate
         self._max_depth = max_depth
+        self._exclude_resources = exclude_resources
 
         # Load programmatic skills first (highest priority)
         if skills is not None:
@@ -338,6 +344,7 @@ class SkillsToolset(FunctionToolset[Any]):
                     path=directory,
                     validate=self._validate,
                     max_depth=self._max_depth,
+                    exclude_resources=self._exclude_resources,
                 )
             self._skill_directories.append(skill_dir)
 

--- a/pydantic_ai_skills/types.py
+++ b/pydantic_ai_skills/types.py
@@ -12,7 +12,7 @@ Data classes:
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
@@ -266,6 +266,7 @@ class Skill:
         path: str | Path,
         validate: bool = True,
         script_executor: LocalSkillScriptExecutor | CallableSkillScriptExecutor | None = None,
+        exclude_resources: Iterable[str] | None = None,
     ) -> Skill:
         """Load a :class:`Skill` from a SKILL.md file or its parent directory.
 
@@ -277,6 +278,10 @@ class Skill:
                 field).  Metadata quality issues (bad name format, missing description,
                 overlong body) emit :class:`UserWarning` regardless of this flag.
             script_executor: Optional custom script executor for file-based scripts.
+            exclude_resources: Extra glob patterns to exclude from resource discovery,
+                in addition to the built-in defaults (``__pycache__``, ``*.pyc``,
+                ``.DS_Store`` …). None for defaults only. Any readable text file not
+                excluded and not discovered as a script becomes a resource.
 
         Returns:
             A :class:`Skill` instance.
@@ -331,8 +336,12 @@ class Skill:
             validate_skill_metadata(frontmatter, instructions, uri=str(skill_folder))
 
         executor = script_executor or _LocalExecutor()
-        resources = _discover_resources(skill_folder)
         scripts = _discover_scripts(skill_folder, name, executor)
+        resources = _discover_resources(
+            skill_folder,
+            exclude_resources,
+            script_uris={script.uri for script in scripts if script.uri},
+        )
 
         return cls(
             name=name,

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -184,6 +184,25 @@ def test_skills_capability_from_spec_builds_toolset(tmp_path: Path) -> None:
     assert capability.get_description() == 'Catalog text.'
 
 
+def test_skills_capability_from_spec_threads_exclude_resources(tmp_path: Path) -> None:
+    """from_spec should thread exclude_resources into discovery."""
+    skill_dir = tmp_path / 'sql-skill'
+    skill_dir.mkdir()
+    (skill_dir / 'SKILL.md').write_text(
+        '---\nname: sql-skill\ndescription: The sql-skill.\n---\n# sql-skill\nRead report.sql.\n',
+        encoding='utf-8',
+    )
+    (skill_dir / 'report.sql').write_text('SELECT 1;', encoding='utf-8')
+    (skill_dir / 'notes.txt').write_text('notes', encoding='utf-8')
+
+    capability = SkillsCapability.from_spec(directories=[str(tmp_path)], exclude_resources=['*.sql'])
+
+    skill = capability.toolset.get_skill('sql-skill')
+    resource_names = [r.name for r in skill.resources or []]
+    assert 'report.sql' not in resource_names
+    assert 'notes.txt' in resource_names
+
+
 def test_skills_capability_from_spec_defer_loading_requires_id() -> None:
     """from_spec should enforce the same defer_loading/id invariant as the constructor."""
     with pytest.raises(ValueError, match="requires a stable 'id'"):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -283,6 +283,156 @@ Content.
     assert 'resources/nested/data.csv' in resource_names
 
 
+def _write_skill_with_sql(tmp_path: Path) -> Path:
+    """Create a skill directory shipping a .sql resource and return the root."""
+    skill_dir = tmp_path / 'sql-skill'
+    skill_dir.mkdir()
+    (skill_dir / 'SKILL.md').write_text("""---
+name: sql-skill
+description: Skill shipping a SQL query
+---
+
+Read queries/report.sql for the query.
+""")
+    queries_dir = skill_dir / 'queries'
+    queries_dir.mkdir()
+    (queries_dir / 'report.sql').write_text('SELECT 1;')
+    (skill_dir / 'notes.txt').write_text('notes')
+    return tmp_path
+
+
+def test_discover_skills_arbitrary_text_extension_by_default(tmp_path: Path) -> None:
+    """Any readable text file is a resource by default, including .sql."""
+    root = _write_skill_with_sql(tmp_path)
+
+    skills = discover_skills(root, validate=True)
+
+    assert len(skills) == 1
+    resource_names = {r.name for r in skills[0].resources or []}
+    assert 'queries/report.sql' in resource_names
+    assert 'notes.txt' in resource_names
+
+
+def test_discover_skills_skips_binary_files(tmp_path: Path) -> None:
+    """Binary files (NUL byte) are not registered as resources."""
+    root = _write_skill_with_sql(tmp_path)
+    (root / 'sql-skill' / 'logo.png').write_bytes(b'\x89PNG\r\n\x00\x00binary')
+
+    skills = discover_skills(root, validate=True)
+
+    resource_names = {r.name for r in skills[0].resources or []}
+    assert 'logo.png' not in resource_names
+
+
+def test_discover_skills_rejects_invalid_utf8(tmp_path: Path) -> None:
+    """A file that is not valid UTF-8 is skipped, even without a NUL byte.
+
+    The loader reads resources as UTF-8, so discovery must reject anything it
+    could not decode (here, a stray 0xFF byte the old NUL-only sniff missed).
+    """
+    root = _write_skill_with_sql(tmp_path)
+    (root / 'sql-skill' / 'data.bin').write_bytes(b'\xff\xfe not utf-8')
+
+    skills = discover_skills(root, validate=True)
+
+    resource_names = {r.name for r in skills[0].resources or []}
+    assert 'data.bin' not in resource_names
+    assert 'notes.txt' in resource_names
+
+
+def test_discover_skills_accepts_multibyte_utf8(tmp_path: Path) -> None:
+    """Valid multibyte UTF-8 content is a resource and reads back intact."""
+    skill_dir = tmp_path / 'unicode-skill'
+    skill_dir.mkdir()
+    (skill_dir / 'SKILL.md').write_text("""---
+name: unicode-skill
+description: Skill with unicode content
+---
+
+See emoji.md.
+""")
+    (skill_dir / 'emoji.md').write_text('# café 🚀 日本語\n', encoding='utf-8')
+
+    skills = discover_skills(tmp_path, validate=True)
+
+    resource_names = {r.name for r in skills[0].resources or []}
+    assert 'emoji.md' in resource_names
+
+
+def test_discover_skills_excludes_scripts_from_resources(tmp_path: Path) -> None:
+    """Files discovered as scripts are not also registered as resources."""
+    skill_dir = tmp_path / 'script-skill'
+    skill_dir.mkdir()
+    (skill_dir / 'SKILL.md').write_text("""---
+name: script-skill
+description: Skill with a script and a resource
+---
+
+Run run.py; read notes.md.
+""")
+    (skill_dir / 'run.py').write_text('print("hi")\n')
+    (skill_dir / 'notes.md').write_text('# Notes\n')
+
+    skills = discover_skills(tmp_path, validate=True)
+
+    skill = skills[0]
+    resource_names = {r.name for r in skill.resources or []}
+    script_names = {s.name for s in skill.scripts or []}
+    assert 'run.py' in script_names
+    assert 'run.py' not in resource_names
+    assert 'notes.md' in resource_names
+
+
+def test_discover_skills_default_excludes_noise(tmp_path: Path) -> None:
+    """__pycache__ and .DS_Store are excluded by the default patterns."""
+    skill_dir = tmp_path / 'noisy-skill'
+    skill_dir.mkdir()
+    (skill_dir / 'SKILL.md').write_text("""---
+name: noisy-skill
+description: Skill with noise files
+---
+
+Content.
+""")
+    (skill_dir / 'keep.txt').write_text('keep')
+    (skill_dir / '.DS_Store').write_text('junk')
+    pycache = skill_dir / '__pycache__'
+    pycache.mkdir()
+    (pycache / 'mod.cpython-312.pyc').write_text('cached')
+
+    skills = discover_skills(tmp_path, validate=True)
+
+    resource_names = {r.name for r in skills[0].resources or []}
+    assert 'keep.txt' in resource_names
+    assert '.DS_Store' not in resource_names
+    assert not any(name.startswith('__pycache__/') for name in resource_names)
+
+
+def test_discover_skills_exclude_resources_extends_defaults(tmp_path: Path) -> None:
+    """User exclude patterns are additive; defaults still apply."""
+    root = _write_skill_with_sql(tmp_path)
+    (root / 'sql-skill' / '.DS_Store').write_text('junk')
+
+    skills = discover_skills(root, validate=True, exclude_resources=['*.sql'])
+
+    resource_names = {r.name for r in skills[0].resources or []}
+    assert 'queries/report.sql' not in resource_names  # user pattern
+    assert '.DS_Store' not in resource_names  # default still applied
+    assert 'notes.txt' in resource_names
+
+
+def test_skills_directory_exclude_resources(tmp_path: Path) -> None:
+    """SkillsDirectory threads exclude_resources through to discovery."""
+    root = _write_skill_with_sql(tmp_path)
+
+    source = SkillsDirectory(path=root, exclude_resources=['queries/*.sql'])
+
+    skills = list(source.skills.values())
+    resource_names = {r.name for r in skills[0].resources or []}
+    assert 'queries/report.sql' not in resource_names
+    assert 'notes.txt' in resource_names
+
+
 def test_skills_directory_missing_name_with_validation(tmp_path: Path) -> None:
     """SkillsDirectory with validate=True raises on a skill missing its name."""
     skill_dir = tmp_path / 'nameless'

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -611,9 +611,10 @@ async def test_load_skill_unknown_raises_model_retry(sample_skills_dir: Path) ->
 
     toolset = SkillsToolset(directories=[sample_skills_dir])
     load_skill = toolset.tools['load_skill'].function
+    ctx = Mock()
 
     with pytest.raises(ModelRetry) as exc_info:
-        await load_skill(Mock(), 'does-not-exist')
+        await load_skill(ctx, 'does-not-exist')
 
     msg = str(exc_info.value)
     assert 'does-not-exist' in msg
@@ -627,9 +628,10 @@ async def test_read_skill_resource_unknown_skill_raises_model_retry(sample_skill
 
     toolset = SkillsToolset(directories=[sample_skills_dir])
     read_skill_resource = toolset.tools['read_skill_resource'].function
+    ctx = Mock()
 
     with pytest.raises(ModelRetry, match="Skill 'ghost' not found"):
-        await read_skill_resource(Mock(), 'ghost', 'FORMS.md')
+        await read_skill_resource(ctx, 'ghost', 'FORMS.md')
 
 
 @pytest.mark.asyncio
@@ -639,9 +641,10 @@ async def test_read_skill_resource_unknown_resource_raises_model_retry(sample_sk
 
     toolset = SkillsToolset(directories=[sample_skills_dir])
     read_skill_resource = toolset.tools['read_skill_resource'].function
+    ctx = Mock()
 
     with pytest.raises(ModelRetry) as exc_info:
-        await read_skill_resource(Mock(), 'skill-two', 'NONEXISTENT.md')
+        await read_skill_resource(ctx, 'skill-two', 'NONEXISTENT.md')
 
     msg = str(exc_info.value)
     assert 'NONEXISTENT.md' in msg
@@ -655,9 +658,10 @@ async def test_run_skill_script_unknown_skill_raises_model_retry(sample_skills_d
 
     toolset = SkillsToolset(directories=[sample_skills_dir])
     run_skill_script = toolset.tools['run_skill_script'].function
+    ctx = Mock()
 
     with pytest.raises(ModelRetry, match="Skill 'ghost' not found"):
-        await run_skill_script(Mock(), 'ghost', 'hello.py')
+        await run_skill_script(ctx, 'ghost', 'hello.py')
 
 
 @pytest.mark.asyncio
@@ -667,9 +671,10 @@ async def test_run_skill_script_unknown_script_raises_model_retry(sample_skills_
 
     toolset = SkillsToolset(directories=[sample_skills_dir])
     run_skill_script = toolset.tools['run_skill_script'].function
+    ctx = Mock()
 
     with pytest.raises(ModelRetry) as exc_info:
-        await run_skill_script(Mock(), 'skill-three', 'nope.py')
+        await run_skill_script(ctx, 'skill-three', 'nope.py')
 
     msg = str(exc_info.value)
     assert 'nope.py' in msg

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -163,6 +163,42 @@ async def test_read_skill_resource_tool(sample_skills_dir: Path) -> None:
         assert resource_path.is_file()
 
 
+def test_toolset_discovers_text_resources_by_default(tmp_path: Path) -> None:
+    """Any readable text file is a resource without configuration."""
+    skill_dir = tmp_path / 'sql-skill'
+    skill_dir.mkdir()
+    (skill_dir / 'SKILL.md').write_text("""---
+name: sql-skill
+description: Skill shipping a SQL query
+---
+
+Read report.sql for the query.
+""")
+    (skill_dir / 'report.sql').write_text('SELECT 1;')
+
+    toolset = SkillsToolset(directories=[tmp_path])
+    names = [r.name for r in toolset.get_skill('sql-skill').resources or []]
+    assert 'report.sql' in names
+
+
+def test_toolset_exclude_resources(tmp_path: Path) -> None:
+    """SkillsToolset threads exclude_resources through directory discovery."""
+    skill_dir = tmp_path / 'sql-skill'
+    skill_dir.mkdir()
+    (skill_dir / 'SKILL.md').write_text("""---
+name: sql-skill
+description: Skill shipping a SQL query
+---
+
+Read report.sql for the query.
+""")
+    (skill_dir / 'report.sql').write_text('SELECT 1;')
+
+    toolset = SkillsToolset(directories=[tmp_path], exclude_resources=['*.sql'])
+    names = [r.name for r in toolset.get_skill('sql-skill').resources or []]
+    assert 'report.sql' not in names
+
+
 @pytest.mark.asyncio
 async def test_read_skill_resource_not_found(sample_skills_dir: Path) -> None:
     """Test reading a non-existent resource."""


### PR DESCRIPTION
## What & why

Closes #54. Resource discovery used a hardcoded extension allowlist (`.md`, `.json`, `.yaml`, `.yml`, `.csv`, `.xml`, `.txt`) with no way to extend it, so common text assets a skill ships — `.sql`, `.toml`, `.jinja`, `.tmpl` — were silently invisible to the model, even when `SKILL.md` referenced them by name. `read_skill_resource(...)` would then raise `ModelRetry("... not found")`.

Rather than just widening the allowlist, this flips the model: **any readable text file in the skill folder is a resource**, with guardrails to keep discovery safe and quiet.

## What changed

- **Allow-all-text discovery** ([directory.py](../blob/feat/resource-discovery-all-text-files/pydantic_ai_skills/directory.py)): every file that decodes as UTF-8, in any subdirectory, becomes a resource. `_discover_resources` was rewritten from per-extension `rglob` loops to a single `rglob('*')` + filter.
- **Bounded text detection**: `_is_text_file` decodes at most a 64 KB prefix (via an incremental UTF-8 decoder), matching the loader's `read_text('utf-8')` contract without reading whole files. Files that fit in the window are validated exactly; larger files are prefix-checked (a multibyte char split by the window is not a false reject). Binaries fail on the first invalid byte.
- **Scripts are never resources**: files discovered by `_discover_scripts` are excluded from resources via a `script_uris` set (scripts discovered first, then passed into resource discovery).
- **New `exclude_resources` parameter**: glob patterns that **extend** (never replace) the built-in `DEFAULT_RESOURCE_EXCLUDES` (`__pycache__`, `*.pyc`, `*.pyo`, `.DS_Store`, `.git`). A pattern matches the full skill-relative posix path or any single path component. Threaded through `discover_skills`, `SkillsDirectory`, `Skill.from_file`, `SkillsToolset`, and `SkillsCapability` (+ `from_spec`, so it works in agent specs). `DEFAULT_RESOURCE_EXCLUDES` is exported for easy extension.

## Reviewer notes

- **Behavior change**: skills may now expose more files by default (e.g. a stray `.log` or `notes.org`). This is intentional and matches our expectations that files in the skill bundle are readable; noise/binaries are filtered.
- **`exclude_resources` is a deny-list, not an allow-list** — its default contains noise patterns, so allow-list semantics wouldn't make sense. User patterns are additive so noise stays excluded even when custom patterns are supplied.
- **UTF-8 is hardcoded** in `_is_text_file` to stay in lockstep with the loader's `read_text('utf-8')`. If the loader's encoding ever becomes configurable, this must track it.
- Docs updated in [creating-skills.md](../blob/feat/resource-discovery-all-text-files/docs/creating-skills.md); API-reference docstrings flow through mkdocstrings.

## Tests

Added coverage for: arbitrary text extensions discovered by default, binary skip, invalid-UTF-8 rejection (a case the old approach would misclassify), multibyte acceptance, script exclusion, default noise exclusion, and additive `exclude_resources` — across discovery, toolset, and capability layers. Full suite: **459 passed**; pre-commit (ruff + mypy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)