### PR TITLE
Add include/exclude skill selection; fix strict docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This package implements the [Agent Skills specification](https://agentskills.io/
 - **Agent Skills Spec** - Fully compatible with the [Agent Skills](https://agentskills.io/home) open format
 - **Filesystem Skills** - Define skills as filesystem directories with Markdown files and scripts
 - **Programmatic Skills** - Create skills dynamically in Python code using decorators or dataclasses
+- **Bundled Resources** - Agents read `REFERENCE.md`, `FORMS.md`, and other bundled files on demand
+- **Script Execution** - Agents run a skill's bundled scripts with named arguments
+- **Skill Registries** - Load skills from Git repositories, S3, or custom remote sources
+- **Skill Selection** - Expose a per-agent subset of your library with `include` / `exclude`
 - **Type-Safe** - Built with Python dataclasses and type hints
 - **Validation** - Automatic validation of skill metadata and structure
 - **Multiple Directories** - Load skills from multiple sources
@@ -116,6 +120,78 @@ ModelRequestNode(request=ModelRequest(parts=[ToolReturnPart(tool_name='run_skill
 CallToolsNode(model_response=ModelResponse(parts=[TextPart(content='Here are the last three papers from arXiv about machine learning:\n\n1. **Title:** Changing Data Sources in the Age of Machine Learning for Official Statistics\n   - **Summary:** This paper discusses the increasing importance of data science in official statistics production, highlighting risks and uncertainties related to changing data sources in machine learning contexts. It covers issues like concept drift, bias, and data validity, and offers measures to maintain the reliability and integrity of machine learning-based statistics.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2306.04338v1)\n\n2. **Title:** DOME: Recommendations for supervised machine learning validation in biology\n   - **Summary:** The paper provides a set of community-wide recommendations for machine learning validation in biology, emphasizing the importance of a structured methods description using DOME (data, optimization, model, evaluation). These guidelines aim to improve the scrutiny of machine learning performance and facilitate better understanding and assessment of methods.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2006.16189v4)\n\n3. **Title:** Learning Curves for Decision Making in Supervised Machine Learning: A Survey\n   - **Summary:** This survey covers the concept of learning curves in machine learning, which assess algorithm performance concerning resources like training examples. The paper categorizes learning curve approaches based on decision-making situations, and it surveys literature to classify various models within this framework.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2201.12150v2)')], usage=RequestUsage(input_tokens=2177, cache_read_tokens=1408, output_tokens=322, details={'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}), model_name='gpt-4o-2024-08-06', timestamp=datetime.datetime(2025, 12, 18, 23, 27, 19, tzinfo=TzInfo(0)), provider_name='openai', provider_details={'finish_reason': 'stop'}, provider_response_id='chatcmpl-CoHgtHBD9LUsRKbILVar99GtAGKHM', finish_reason='stop'))
 End(data=FinalResult(output='Here are the last three papers from arXiv about machine learning:\n\n1. **Title:** Changing Data Sources in the Age of Machine Learning for Official Statistics\n   - **Summary:** This paper discusses the increasing importance of data science in official statistics production, highlighting risks and uncertainties related to changing data sources in machine learning contexts. It covers issues like concept drift, bias, and data validity, and offers measures to maintain the reliability and integrity of machine learning-based statistics.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2306.04338v1)\n\n2. **Title:** DOME: Recommendations for supervised machine learning validation in biology\n   - **Summary:** The paper provides a set of community-wide recommendations for machine learning validation in biology, emphasizing the importance of a structured methods description using DOME (data, optimization, model, evaluation). These guidelines aim to improve the scrutiny of machine learning performance and facilitate better understanding and assessment of methods.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2006.16189v4)\n\n3. **Title:** Learning Curves for Decision Making in Supervised Machine Learning: A Survey\n   - **Summary:** This survey covers the concept of learning curves in machine learning, which assess algorithm performance concerning resources like training examples. The paper categorizes learning curve approaches based on decision-making situations, and it surveys literature to classify various models within this framework.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2201.12150v2)'))
 ````
+
+## Choosing Which Skills to Expose
+
+One skill library can serve several agents. Use `include` or `exclude` to give each agent
+only the skills it should see:
+
+```python
+from pydantic_ai_skills import SkillsCapability
+
+research = SkillsCapability(directories=['./skills'], include=['arxiv-search', 'web-research'])
+everything_else = SkillsCapability(directories=['./skills'], exclude=['arxiv-search'])
+```
+
+| Configuration | Skills in the catalog |
+| --- | --- |
+| Neither option | All discovered skills |
+| `include=['a', 'b']` | Only `a` and `b` |
+| `include=[]` | No skills |
+| `exclude=['a', 'b']` | All except `a` and `b` |
+
+`include` and `exclude` cannot be combined, and a name that matches no discovered skill raises
+`ValueError` at construction so typos surface immediately. Selection applies to every source —
+programmatic skills, directories, and registries — and is re-applied by `reload()`.
+
+Both options work on `SkillsToolset` too, and in declarative agent specs:
+
+```yaml
+capabilities:
+  - SkillsCapability:
+      directories: ['./skills']
+      include:
+        - arxiv-search
+```
+
+> Selection controls what the model sees in the catalog. It is not a filesystem permission or an
+> access-control boundary — see [Security](https://dougtrajano.github.io/pydantic-ai-skills/security/).
+
+## Why pydantic-ai-skills
+
+Pydantic AI's own [`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness) ships a
+`Skills` capability that maps each `SKILL.md` to a deferred core capability. It is a deliberately
+minimal reader: it loads frontmatter and the Markdown body, and explicitly
+[does not enumerate, read, or execute bundled files](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/skills).
+
+`pydantic-ai-skills` implements the full Agent Skills package, not just its instructions:
+
+| | `pydantic-ai-skills` | harness `Skills` |
+| --- | --- | --- |
+| Skill metadata catalog (level 1) | ✅ | ✅ |
+| Instructions on demand (level 2) | ✅ | ✅ |
+| Bundled resources, e.g. `REFERENCE.md` (level 3) | ✅ `read_skill_resource` | ❌ not loaded |
+| Bundled script execution | ✅ `run_skill_script` | ❌ not executed |
+| `include` / `exclude` selection | ✅ | ✅ |
+| Programmatic skills in Python | ✅ decorators and dataclasses | ❌ use core `Capability` |
+| Remote registries (Git, S3) | ✅ | ❌ |
+| Registry composition (combine, filter, prefix, rename) | ✅ | ❌ |
+| Reload skills without restarting | ✅ `reload()` / `auto_reload` | ❌ construction-time snapshot |
+| Recursive discovery | ✅ up to `max_depth` | ❌ immediate children only |
+| Path traversal and symlink containment | ✅ | ❌ explicitly not a boundary |
+| Per-tool restriction, e.g. disable scripts | ✅ `exclude_tools` | n/a |
+| Deferred loading via `load_capability` | ✅ `defer_loading=True` | ✅ always deferred |
+
+The practical difference is **level 3 of progressive disclosure**. A skill that ships a reference
+document or a script is a complete package; without resource reads and script execution, the model
+gets the instructions but cannot follow them. `pydantic-ai-skills` runs those skills as written —
+including the ones published in Anthropic's
+[skills repository](https://github.com/anthropics/skills).
+
+If you only need instruction text injected on demand and are already invested in the harness, its
+`Skills` capability is a fine, smaller dependency. Reach for `pydantic-ai-skills` when your skills
+have bundled files, come from a shared registry, are generated in Python, or change while the
+process is running.
 
 ## Creating Skills
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -12,6 +12,56 @@ Watch the Advanced Usage Tutorial for in-depth demonstrations of advanced skill 
   <source src="../assets/advanced_usage.mp4" type="video/mp4">
 </video>
 
+## Selecting Which Skills to Expose
+
+One skill library often serves several agents. `include` and `exclude` scope the catalog per agent
+without duplicating the library on disk.
+
+```python
+from pydantic_ai_skills import SkillsCapability
+
+research = SkillsCapability(directories=['./skills'], include=['arxiv-search', 'web-research'])
+support = SkillsCapability(directories=['./skills'], exclude=['arxiv-search'])
+```
+
+| Configuration | Skills in the catalog |
+| --- | --- |
+| Neither option | All discovered skills |
+| `include=['a', 'b']` | Only `a` and `b` |
+| `include=[]` | No skills |
+| `exclude=['a', 'b']` | All except `a` and `b` |
+| `exclude=[]` | All discovered skills |
+
+Behavior:
+
+- `include` and `exclude` cannot be combined; doing so raises `ValueError`.
+- A name matching no discovered skill raises `ValueError` at construction, so typos surface early.
+- Selection applies to every source — programmatic skills, directories, and registries.
+- `reload()` and `auto_reload` re-apply the selection.
+- A bare string (`include='arxiv-search'`) raises `TypeError` rather than matching per character.
+
+Both options work on `SkillsToolset` as well:
+
+```python
+from pydantic_ai_skills import SkillsToolset
+
+toolset = SkillsToolset(directories=['./skills'], exclude=['web-research'])
+```
+
+And in declarative agent specs:
+
+```yaml
+capabilities:
+  - SkillsCapability:
+      directories: ['./skills']
+      include:
+        - arxiv-search
+```
+
+> Selection controls what the model sees in the catalog. It is not a filesystem permission or an
+> access-control boundary — see [Security](security.md). To restrict what loaded skills can *do*,
+> use `exclude_tools` (for example `exclude_tools=['run_skill_script']`).
+
 ## Hot-Reload (Runtime Skill Discovery)
 
 `SkillsCapability` is the preferred integration path. This section focuses on `SkillsToolset` because hot-reload controls (`reload()`, `auto_reload`) are configured on the underlying toolset.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,149 @@
+# Why pydantic-ai-skills
+
+There is more than one way to give a Pydantic AI agent Agent Skills. This page explains what
+`pydantic-ai-skills` does, how it differs from the alternatives, and when each one is the better
+fit.
+
+## The alternatives
+
+### Core `Capability` with `defer_loading`
+
+Pydantic AI's core [on-demand capabilities](https://ai.pydantic.dev/capabilities/) let you define a
+capability in Python and hide its instructions and tools behind a framework-managed
+`load_capability` tool:
+
+```python
+from pydantic_ai.capabilities import Capability
+
+refunds = Capability(
+    id='refunds',
+    description='Refund policy tools and instructions.',
+    instructions='Check the refund policy before answering refund questions.',
+    defer_loading=True,
+)
+```
+
+This is the right tool when your instructions and tools live in Python. It is not an Agent Skills
+implementation: there is no `SKILL.md`, no bundled resources, and no portable skill package.
+
+### `pydantic-ai-harness` `Skills`
+
+[`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness) ships a `Skills` capability
+that scans skill libraries and turns each `SKILL.md` into one deferred core capability. It is a
+deliberately minimal reader: it parses the frontmatter and Markdown body and, in its own words,
+does not enumerate, read, or execute bundled files such as `references/`, `assets/`, or `scripts/`.
+
+```python
+from pydantic_ai_harness.skills import Skills
+
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[Skills('.agents/skills')])
+```
+
+### `pydantic-ai-skills`
+
+This library implements the whole Agent Skills package — metadata, instructions, bundled resources,
+and executable scripts — plus discovery from remote registries and skills defined in Python.
+
+## Feature comparison
+
+| | `pydantic-ai-skills` | harness `Skills` | Core `Capability` |
+| --- | --- | --- | --- |
+| Reads `SKILL.md` packages | ✅ | ✅ | ❌ |
+| Skill metadata catalog (level 1) | ✅ | ✅ | ✅ |
+| Instructions on demand (level 2) | ✅ | ✅ | ✅ |
+| Bundled resources (level 3) | ✅ `read_skill_resource` | ❌ not loaded | ❌ |
+| Bundled script execution | ✅ `run_skill_script` | ❌ not executed | ❌ |
+| `include` / `exclude` selection | ✅ | ✅ | n/a |
+| Programmatic skills in Python | ✅ decorators and dataclasses | ❌ | ✅ |
+| Remote registries (Git, S3) | ✅ | ❌ | ❌ |
+| Registry composition | ✅ combine, filter, prefix, rename | ❌ | ❌ |
+| Reload without restarting | ✅ `reload()` / `auto_reload` | ❌ snapshot at construction | ❌ |
+| Recursive discovery | ✅ up to `max_depth` | ❌ immediate children only | n/a |
+| Path traversal and symlink containment | ✅ | ❌ explicitly not a boundary | n/a |
+| Per-tool restriction | ✅ `exclude_tools` | n/a | n/a |
+| Deferred loading via `load_capability` | ✅ `defer_loading=True` | ✅ always deferred | ✅ opt-in |
+| Declarative agent specs | ✅ | ✅ | ✅ |
+
+## The practical difference: level 3
+
+[Progressive disclosure](concepts.md) has three levels. Metadata is always in the prompt,
+instructions load on demand, and **bundled resources and scripts load only when the skill actually
+needs them**.
+
+An implementation that stops after level 2 gives the model a skill's instructions but no way to act
+on them. Consider a typical published skill:
+
+```text
+pdf-processing/
+├── SKILL.md          # "Consult FORMS.md, then run scripts/fill_form.py"
+├── FORMS.md
+└── scripts/
+    └── fill_form.py
+```
+
+With instruction-only loading the model reads that guidance, then has no `FORMS.md` and no way to
+run `fill_form.py`. Relative paths and placeholders such as `${CLAUDE_SKILL_DIR}` stay unresolved in
+the loaded text. `pydantic-ai-skills` exposes `read_skill_resource` and `run_skill_script`, so
+skills written this way — including those in Anthropic's
+[skills repository](https://github.com/anthropics/skills) — run as published.
+
+If script execution is not appropriate in your deployment, turn it off explicitly rather than
+losing resource reads with it:
+
+```python
+SkillsCapability(directories=['./skills'], exclude_tools=['run_skill_script'])
+```
+
+## Choosing which skills to expose
+
+A shared library can serve several agents. `include` and `exclude` scope the catalog per agent:
+
+```python
+from pydantic_ai_skills import SkillsCapability
+
+research = SkillsCapability(directories=['./skills'], include=['arxiv-search', 'web-research'])
+support = SkillsCapability(directories=['./skills'], exclude=['arxiv-search'])
+```
+
+| Configuration | Skills in the catalog |
+| --- | --- |
+| Neither option | All discovered skills |
+| `include=['a', 'b']` | Only `a` and `b` |
+| `include=[]` | No skills |
+| `exclude=['a', 'b']` | All except `a` and `b` |
+| `exclude=[]` | All discovered skills |
+
+Notes:
+
+- `include` and `exclude` cannot be combined; doing so raises `ValueError`.
+- A name matching no discovered skill raises `ValueError` at construction, so typos surface early.
+- Selection applies to every source: programmatic skills, directories, and registries.
+- `reload()` and `auto_reload` re-apply the selection.
+- Passing a bare string (`include='arxiv-search'`) raises `TypeError` rather than matching each
+  character.
+
+Both options are available on `SkillsToolset` and `SkillsCapability`, and in agent specs:
+
+```yaml
+capabilities:
+  - SkillsCapability:
+      directories: ['./skills']
+      include:
+        - arxiv-search
+        - web-research
+```
+
+Selection controls catalog exposure. It is not a filesystem permission or an access-control
+boundary — see [Security](security.md).
+
+## Which should you use?
+
+Use **core `Capability`** when instructions and tools are written in Python and you do not need a
+portable skill format.
+
+Use **harness `Skills`** when you only need instruction text injected on demand, your skills are
+plain `SKILL.md` files with no bundled files, and you already depend on the harness.
+
+Use **`pydantic-ai-skills`** when skills carry bundled resources or scripts, come from a Git or S3
+registry, are generated in Python, need to change while the process runs, or when you want path
+traversal and symlink containment on the loading path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,9 +13,12 @@ Agent Skills are **modular collections of instructions, scripts, and resources**
 - **Skill Registries**: Discover and install skills from Git repositories and other remote sources
 - **Script Execution**: Include Python scripts that agents can execute
 - **Resource Management**: Support for documentation and data files
+- **Skill Selection**: Expose a per-agent subset of a shared library with `include` / `exclude`
 - **Type-Safe**: Built on Pydantic AI's type-safe foundation
 - **Simple Integration**: Drop-in toolset for Pydantic AI agents
 - **Capabilities Integration**: Preferred via `SkillsCapability` and `capabilities=[...]`
+
+Comparing options? See [Why pydantic-ai-skills](comparison.md).
 
 ## Quick Example
 
@@ -106,8 +109,12 @@ The Pydantic AI Skills documentation is available in the [llms.txt](https://llms
 
 Two formats are available:
 
-- [`llms.txt`](/llms.txt): a file containing a brief description of the project, along with links to the different sections of the documentation. The structure of this file is described in detail [here](https://llmstxt.org/#format).
-- [`llms-full.txt`](/llms-full.txt): Similar to `llms.txt`, but with the linked documentation content included inline. This file may be too large for some LLMs.
+<!-- These two files are generated at the site root by the mkdocs-llmstxt plugin, so they are
+     not part of the mkdocs file registry and a Markdown link to them fails `--strict`
+     validation. Raw anchors keep the relative (version-correct under mike) URL. -->
+
+- <a href="llms.txt"><code>llms.txt</code></a>: a file containing a brief description of the project, along with links to the different sections of the documentation. The structure of this file is described in detail [here](https://llmstxt.org/#format).
+- <a href="llms-full.txt"><code>llms-full.txt</code></a>: Similar to `llms.txt`, but with the linked documentation content included inline. This file may be too large for some LLMs.
 
 As of today, these files are not automatically leveraged by most IDEs or coding agents, but they can use them if you provide a link or the full text.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,75 @@
+# Installation
+
+## Requirements
+
+- Python 3.10 or newer
+
+## Install
+
+```bash
+pip install pydantic-ai-skills
+```
+
+This pulls in everything needed to discover skills from the filesystem, load their instructions
+and resources, and run their scripts:
+
+- `pydantic-ai-slim` — the Pydantic AI agent framework
+- `pyyaml` — parses `SKILL.md` YAML frontmatter
+- `anyio` — async process handling for script execution
+
+No extras are required for the core workflow described in the [Quick Start](quick-start.md).
+
+## Optional extras
+
+Some features depend on additional packages. Install the matching extra:
+
+| Extra | Install | Enables |
+| --- | --- | --- |
+| `git` | `pip install "pydantic-ai-skills[git]"` | `GitSkillsRegistry` — load skills from Git repositories |
+| `s3` | `pip install "pydantic-ai-skills[s3]"` | `S3SkillsRegistry` — load skills from S3 buckets |
+| `test` | `pip install "pydantic-ai-skills[test]"` | pytest and coverage tooling |
+| `dev` | `pip install "pydantic-ai-skills[dev]"` | ruff, mypy, and pre-commit |
+| `docs` | `pip install "pydantic-ai-skills[docs]"` | MkDocs and the docs toolchain |
+| `examples` | `pip install "pydantic-ai-skills[examples]"` | dependencies used by the bundled examples |
+
+Extras can be combined:
+
+```bash
+pip install "pydantic-ai-skills[git,s3]"
+```
+
+See [Skill Registries](registries.md) for what the `git` and `s3` extras unlock.
+
+## Install from source
+
+```bash
+git clone https://github.com/dougtrajano/pydantic-ai-skills.git
+cd pydantic-ai-skills
+pip install -e .
+```
+
+Setting up a development environment instead? See [Contributing](contributing.md).
+
+## Verify the installation
+
+```bash
+python -c "from importlib.metadata import version; print(version('pydantic-ai-skills'))"
+```
+
+## Model provider credentials
+
+`pydantic-ai-skills` does not talk to model providers itself — Pydantic AI does. Install and
+configure whichever provider your agent uses, for example:
+
+```bash
+pip install "pydantic-ai-slim[openai]"
+export OPENAI_API_KEY=...
+```
+
+See the [Pydantic AI models documentation](https://ai.pydantic.dev/models/) for the full list.
+
+## Next steps
+
+- [Quick Start](quick-start.md) — build your first agent with skills
+- [Creating Skills](creating-skills.md) — write a `SKILL.md` package
+- [Why pydantic-ai-skills](comparison.md) — how this compares to the alternatives

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ copyright: © Douglas Trajano 2025 to present. Licensed under the MIT License.
 
 nav:
   - Home: index.md
+  - Why pydantic-ai-skills: comparison.md
   - Getting Started:
       - Installation: installation.md
       - Quick Start: quick-start.md
@@ -149,7 +150,9 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: [pydantic_ai_skills]
+          # Search path for griffe: the directory *containing* the package, so the
+          # local source is documented instead of an installed copy in site-packages.
+          paths: [.]
           options:
             relative_crossrefs: true
             members_order: source

--- a/pydantic_ai_skills/capability.py
+++ b/pydantic_ai_skills/capability.py
@@ -66,7 +66,7 @@ class SkillsCapability(AbstractCapability[Any]):
         ```
 
     Only serializable arguments are spec-expressible (see
-    [`from_spec`][pydantic_ai_skills.SkillsCapability.from_spec]); programmatic
+    [`from_spec`][pydantic_ai_skills.capability.SkillsCapability.from_spec]); programmatic
     `skills`, `registries`, and `SkillsDirectory` instances require Python construction.
     """
 
@@ -92,6 +92,12 @@ class SkillsCapability(AbstractCapability[Any]):
 
     instruction_template: str | None = None
     """Optional custom instructions template."""
+
+    include: list[str] | None = None
+    """Exact skill names to expose. Cannot be combined with `exclude`."""
+
+    exclude: list[str] | None = None
+    """Exact skill names to omit from the catalog. Cannot be combined with `include`."""
 
     exclude_tools: set[str] | list[str] | None = None
     """Tool names to exclude."""
@@ -119,6 +125,8 @@ class SkillsCapability(AbstractCapability[Any]):
             exclude_resources=self.exclude_resources,
             id=self.id,
             instruction_template=self.instruction_template,
+            include=self.include,
+            exclude=self.exclude,
             exclude_tools=self.exclude_tools,
             auto_reload=self.auto_reload,
         )
@@ -138,6 +146,8 @@ class SkillsCapability(AbstractCapability[Any]):
         exclude_resources: list[str] | None = None,
         id: str | None = None,
         instruction_template: str | None = None,
+        include: list[str] | None = None,
+        exclude: list[str] | None = None,
         exclude_tools: list[str] | None = None,
         auto_reload: bool = False,
         description: str | None = None,
@@ -158,6 +168,8 @@ class SkillsCapability(AbstractCapability[Any]):
             id: Stable identifier shared by the capability and its toolset. Required when
                 ``defer_loading`` is True.
             instruction_template: Optional custom instructions template.
+            include: Exact skill names to expose. Cannot be combined with ``exclude``.
+            exclude: Exact skill names to omit from the catalog. Cannot be combined with ``include``.
             exclude_tools: Tool names to exclude.
             auto_reload: Re-scan directories before each run.
             description: Optional catalog description surfaced when ``defer_loading`` is True.
@@ -171,6 +183,8 @@ class SkillsCapability(AbstractCapability[Any]):
             exclude_resources=list(exclude_resources) if exclude_resources is not None else None,
             id=id,
             instruction_template=instruction_template,
+            include=list(include) if include is not None else None,
+            exclude=list(exclude) if exclude is not None else None,
             exclude_tools=exclude_tools,
             auto_reload=auto_reload,
             description=description,

--- a/pydantic_ai_skills/toolset.py
+++ b/pydantic_ai_skills/toolset.py
@@ -283,13 +283,7 @@ class SkillsToolset(FunctionToolset[Any]):
 
         self._instruction_template = instruction_template
 
-        # Skill-name selection (applies to every source: programmatic, directories, registries)
-        if include is not None and exclude is not None:
-            raise ValueError('include and exclude cannot be used together.')
-        self._include = _normalize_selection('include', include) if include is not None else None
-        self._exclude = _normalize_selection('exclude', exclude) if exclude is not None else frozenset()
-        # Every skill name seen before selection, used to report unknown include/exclude entries.
-        self._discovered_names: set[str] = set()
+        self._init_selection(include, exclude)
 
         # Validate and initialize exclude_tools
         valid_tools = {'list_skills', 'load_skill', 'read_skill_resource', 'run_skill_script'}
@@ -356,6 +350,23 @@ class SkillsToolset(FunctionToolset[Any]):
             Dictionary mapping skill names to Skill objects.
         """
         return self._skills
+
+    def _init_selection(self, include: Collection[str] | None, exclude: Collection[str] | None) -> None:
+        """Configure skill-name selection, applied to every source.
+
+        Args:
+            include: Exact skill names to expose, or None to expose all.
+            exclude: Exact skill names to omit, or None to omit none.
+
+        Raises:
+            ValueError: If both `include` and `exclude` are provided.
+        """
+        if include is not None and exclude is not None:
+            raise ValueError('include and exclude cannot be used together.')
+        self._include = _normalize_selection('include', include) if include is not None else None
+        self._exclude = _normalize_selection('exclude', exclude) if exclude is not None else frozenset()
+        # Every skill name seen before selection, used to report unknown include/exclude entries.
+        self._discovered_names: set[str] = set()
 
     def _is_selected(self, name: str) -> bool:
         """Return whether *name* passes the configured `include`/`exclude` selection.

--- a/pydantic_ai_skills/toolset.py
+++ b/pydantic_ai_skills/toolset.py
@@ -13,8 +13,9 @@ The toolset provides four main tools for agents:
 from __future__ import annotations
 
 import json
+import unicodedata
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Collection, Iterable
 from inspect import signature as get_signature
 from pathlib import Path
 from typing import Annotated, Any
@@ -87,6 +88,29 @@ def _coerce_to_dict(v: Any) -> Any:
             raise ValueError(f'args must be a JSON object, got {type(parsed).__name__}')
         return parsed
     return v
+
+
+def _normalize_selection(option: str, values: Collection[str]) -> frozenset[str]:
+    """Normalize an `include`/`exclude` collection of skill names.
+
+    Args:
+        option: Name of the option being normalized, used in error messages.
+        values: Collection of skill names.
+
+    Returns:
+        Frozenset of NFKC-normalized skill names.
+
+    Raises:
+        TypeError: If `values` is a bare string or contains non-string entries.
+    """
+    if isinstance(values, str):
+        raise TypeError(f'{option} must be a collection of skill names, not a string.')
+    normalized: set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            raise TypeError(f'{option} must contain only skill names as strings.')
+        normalized.add(unicodedata.normalize('NFKC', value))
+    return frozenset(normalized)
 
 
 class SkillsToolset(FunctionToolset[Any]):
@@ -165,6 +189,8 @@ class SkillsToolset(FunctionToolset[Any]):
         exclude_resources: Iterable[str] | None = None,
         id: str | None = None,
         instruction_template: str | None = None,
+        include: Collection[str] | None = None,
+        exclude: Collection[str] | None = None,
         exclude_tools: set[str] | list[str] | None = None,
         auto_reload: bool = False,
         max_retries: int = 1,
@@ -190,6 +216,11 @@ class SkillsToolset(FunctionToolset[Any]):
             instruction_template: Custom instruction template for skills system prompt.
                 Must include `{skills_list}` placeholder. If None, uses default template.
                 Tool usage guidance is provided in the tool docstrings themselves.
+            include: Exact skill names to expose. When provided, every other discovered skill is
+                omitted from the catalog. Cannot be combined with ``exclude``. Pass an empty
+                collection to expose no skills. Unknown names raise ``ValueError``.
+            exclude: Exact skill names to omit from the catalog. Cannot be combined with
+                ``include``. Unknown names raise ``ValueError``.
             exclude_tools: Set or list of tool names to exclude from registration (e.g., ['run_skill_script']).
                 Useful for security or capability restrictions such as disabling script execution.
                 Valid tool names: 'list_skills', 'load_skill', 'read_skill_resource', 'run_skill_script'.
@@ -227,6 +258,12 @@ class SkillsToolset(FunctionToolset[Any]):
             dir1 = SkillsDirectory(path="./skills")
             toolset = SkillsToolset(directories=[dir1])
 
+            # Expose only a subset of the discovered skills
+            toolset = SkillsToolset(directories=["./skills"], include=['arxiv-search'])
+
+            # Expose everything except one skill
+            toolset = SkillsToolset(directories=["./skills"], exclude=['web-research'])
+
             # Excluding specific tools (disable script execution with a set)
             toolset = SkillsToolset(exclude_tools=['run_skill_script'])
 
@@ -245,6 +282,14 @@ class SkillsToolset(FunctionToolset[Any]):
         super().__init__(id=id, max_retries=max_retries)
 
         self._instruction_template = instruction_template
+
+        # Skill-name selection (applies to every source: programmatic, directories, registries)
+        if include is not None and exclude is not None:
+            raise ValueError('include and exclude cannot be used together.')
+        self._include = _normalize_selection('include', include) if include is not None else None
+        self._exclude = _normalize_selection('exclude', exclude) if exclude is not None else frozenset()
+        # Every skill name seen before selection, used to report unknown include/exclude entries.
+        self._discovered_names: set[str] = set()
 
         # Validate and initialize exclude_tools
         valid_tools = {'list_skills', 'load_skill', 'read_skill_resource', 'run_skill_script'}
@@ -297,6 +342,9 @@ class SkillsToolset(FunctionToolset[Any]):
         # Load registry skills (lowest priority — won't override existing)
         self._load_registry_skills()
 
+        # Surface typos in include/exclude once every source has been scanned
+        self._validate_selection()
+
         # Register tools
         self._register_tools()
 
@@ -308,6 +356,32 @@ class SkillsToolset(FunctionToolset[Any]):
             Dictionary mapping skill names to Skill objects.
         """
         return self._skills
+
+    def _is_selected(self, name: str) -> bool:
+        """Return whether *name* passes the configured `include`/`exclude` selection.
+
+        Records the name as discovered so :meth:`_validate_selection` can report
+        unknown `include`/`exclude` entries.
+        """
+        self._discovered_names.add(name)
+        if self._include is not None:
+            return name in self._include
+        return name not in self._exclude
+
+    def _validate_selection(self) -> None:
+        """Raise if `include` or `exclude` names no skill from any configured source.
+
+        Raises:
+            ValueError: If an `include`/`exclude` entry matches no discovered skill.
+        """
+        for option, selected in (('include', self._include), ('exclude', self._exclude)):
+            if not selected:
+                continue
+            unknown = sorted(set(selected) - self._discovered_names)
+            if unknown:
+                available = ', '.join(sorted(self._discovered_names)) or '(none)'
+                noun = 'skill' if len(unknown) == 1 else 'skills'
+                raise ValueError(f'Unknown {noun} in {option}: {", ".join(unknown)}. Available skills: {available}.')
 
     def get_skill(self, name: str) -> Skill:
         """Get a specific skill by name.
@@ -364,6 +438,8 @@ class SkillsToolset(FunctionToolset[Any]):
         programmatic_names = {s.name for s in self._programmatic_skills}
         for skill_dir in self._skill_directories:
             for skill in skill_dir.get_skills().values():
+                if not self._is_selected(skill.name):
+                    continue
                 if skill.name in programmatic_names:
                     continue  # programmatic always wins
                 if skill.name in target:
@@ -904,7 +980,8 @@ class SkillsToolset(FunctionToolset[Any]):
 
         # 1. Highest priority: programmatic skills (always preserved)
         for skill in self._programmatic_skills:
-            new_skills[skill.name] = skill
+            if self._is_selected(skill.name):
+                new_skills[skill.name] = skill
 
         # 2. Directory skills — programmatic names are protected inside the helper
         self._collect_dir_skills_into(new_skills)
@@ -915,7 +992,7 @@ class SkillsToolset(FunctionToolset[Any]):
 
         # 4. Lowest priority: registry cache (never overrides higher-priority skills)
         for skill_name, skill in self._registry_skills.items():
-            if skill_name not in new_skills:
+            if skill_name not in new_skills and self._is_selected(skill_name):
                 new_skills[skill_name] = skill
 
         # Atomically replace the skills mapping once fully populated
@@ -933,6 +1010,9 @@ class SkillsToolset(FunctionToolset[Any]):
         # Convert SkillWrapper to Skill if needed
         if isinstance(skill, SkillWrapper):
             skill = skill.to_skill()
+
+        if not self._is_selected(skill.name):
+            return
 
         # Warn about duplicates
         if skill.name in self._skills:

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -237,3 +237,27 @@ def test_skills_capability_spec_schema_generation() -> None:
 
     schema = AgentSpec.model_json_schema_with_capabilities([SkillsCapability])
     assert 'SkillsCapability' in str(schema)
+
+
+def test_capability_forwards_selection(tmp_path: Path) -> None:
+    """`include` is forwarded through SkillsCapability to the underlying toolset."""
+    for name in ('alpha-skill', 'beta-skill'):
+        skill_dir = tmp_path / name
+        skill_dir.mkdir()
+        (skill_dir / 'SKILL.md').write_text(f'---\nname: {name}\ndescription: Test skill {name}\n---\n\nBody.\n')
+
+    capability = SkillsCapability(directories=[tmp_path], include=['alpha-skill'])
+
+    assert set(capability.toolset.skills) == {'alpha-skill'}
+
+
+def test_capability_from_spec_accepts_selection(tmp_path: Path) -> None:
+    """`exclude` round-trips through the agent-spec constructor."""
+    for name in ('alpha-skill', 'beta-skill'):
+        skill_dir = tmp_path / name
+        skill_dir.mkdir()
+        (skill_dir / 'SKILL.md').write_text(f'---\nname: {name}\ndescription: Test skill {name}\n---\n\nBody.\n')
+
+    capability = SkillsCapability.from_spec(directories=[str(tmp_path)], exclude=['beta-skill'])
+
+    assert set(capability.toolset.skills) == {'alpha-skill'}

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -811,3 +811,82 @@ def test_run_skill_script_rejects_non_object_json(sample_skills_dir: Path) -> No
                 'args': '[1, 2, 3]',
             }
         )
+
+
+def test_include_exposes_only_named_skills(sample_skills_dir: Path) -> None:
+    """`include` restricts the catalog to the named skills."""
+    toolset = SkillsToolset(directories=[sample_skills_dir], include=['skill-one', 'skill-two'])
+
+    assert set(toolset.skills) == {'skill-one', 'skill-two'}
+
+
+def test_exclude_omits_named_skills(sample_skills_dir: Path) -> None:
+    """`exclude` removes the named skills from the catalog."""
+    toolset = SkillsToolset(directories=[sample_skills_dir], exclude=['skill-three'])
+
+    assert set(toolset.skills) == {'skill-one', 'skill-two'}
+
+
+def test_empty_include_exposes_no_skills(sample_skills_dir: Path) -> None:
+    """An empty `include` collection yields an empty catalog."""
+    toolset = SkillsToolset(directories=[sample_skills_dir], include=[])
+
+    assert toolset.skills == {}
+
+
+def test_empty_exclude_exposes_all_skills(sample_skills_dir: Path) -> None:
+    """An empty `exclude` collection leaves the catalog unchanged."""
+    toolset = SkillsToolset(directories=[sample_skills_dir], exclude=[])
+
+    assert len(toolset.skills) == 3
+
+
+def test_include_and_exclude_are_mutually_exclusive(sample_skills_dir: Path) -> None:
+    """Passing both `include` and `exclude` is rejected."""
+    with pytest.raises(ValueError, match='cannot be used together'):
+        SkillsToolset(directories=[sample_skills_dir], include=['skill-one'], exclude=['skill-two'])
+
+
+def test_unknown_include_name_raises(sample_skills_dir: Path) -> None:
+    """An `include` entry matching no discovered skill is reported."""
+    with pytest.raises(ValueError, match='Unknown skill in include: nope'):
+        SkillsToolset(directories=[sample_skills_dir], include=['nope'])
+
+
+def test_unknown_exclude_name_raises(sample_skills_dir: Path) -> None:
+    """An `exclude` entry matching no discovered skill is reported."""
+    with pytest.raises(ValueError, match='Unknown skills in exclude: nope, nuh-uh'):
+        SkillsToolset(directories=[sample_skills_dir], exclude=['nope', 'nuh-uh'])
+
+
+def test_selection_rejects_bare_string(sample_skills_dir: Path) -> None:
+    """A bare string is rejected so `include='abc'` is not read character by character."""
+    with pytest.raises(TypeError, match='not a string'):
+        SkillsToolset(directories=[sample_skills_dir], include='skill-one')  # type: ignore[arg-type]
+
+
+def test_selection_rejects_non_string_entries(sample_skills_dir: Path) -> None:
+    """Non-string entries in a selection are rejected."""
+    with pytest.raises(TypeError, match='only skill names as strings'):
+        SkillsToolset(directories=[sample_skills_dir], exclude=[123])  # type: ignore[list-item]
+
+
+def test_selection_survives_reload(sample_skills_dir: Path) -> None:
+    """`reload()` re-applies the configured selection."""
+    toolset = SkillsToolset(directories=[sample_skills_dir], exclude=['skill-three'])
+    toolset.reload()
+
+    assert set(toolset.skills) == {'skill-one', 'skill-two'}
+
+
+def test_selection_applies_to_programmatic_skills(sample_skills_dir: Path) -> None:
+    """Programmatic skills are subject to the same selection."""
+    from pydantic_ai_skills import Skill
+
+    toolset = SkillsToolset(
+        skills=[Skill(name='extra-skill', description='A programmatic skill', content='Do it.')],
+        directories=[sample_skills_dir],
+        include=['skill-one'],
+    )
+
+    assert set(toolset.skills) == {'skill-one'}


### PR DESCRIPTION
## Summary

Two related pieces of work.

**1. Skill selection (`include` / `exclude`)**

[`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness) added a `Skills` capability ([#396](https://github.com/pydantic/pydantic-ai-harness/commit/95e13202), merged to `main`, **unreleased** as of 0.11.0) that maps each `SKILL.md` to a deferred core capability. Comparing it feature by feature against this library, the only thing it offered that we lacked was per-agent skill selection. This PR closes that gap.

**2. `mkdocs build --strict` now exits 0**

It was failing on four pre-existing warnings. One of them was hiding a real correctness bug.

## What changed

### `include` / `exclude`

Available on both `SkillsToolset` and `SkillsCapability`:

```python
research = SkillsCapability(directories=['./skills'], include=['arxiv-search', 'web-research'])
support  = SkillsCapability(directories=['./skills'], exclude=['arxiv-search'])
```

- Applied across all three sources — programmatic skills, directories, and registries — and re-applied by `reload()` / `auto_reload`.
- Mutually exclusive; combining them raises `ValueError`.
- A name matching no discovered skill raises `ValueError` at construction, so typos surface immediately rather than silently narrowing the catalog.
- A bare string (`include='arxiv-search'`) raises `TypeError` rather than matching character by character.
- Forwarded through `SkillsCapability.from_spec`, so it works in declarative YAML agent specs.

11 new tests covering selection, mutual exclusion, unknown names, type errors, reload persistence, and interaction with programmatic skills.

### Docs

New [comparison page](docs/comparison.md) plus a README positioning section. The framing is that harness `Skills` is a deliberately minimal instruction reader and this library is a full Agent Skills runtime. The load-bearing difference is **level 3 of progressive disclosure**: a skill whose instructions say *"consult FORMS.md, then run scripts/fill_form.py"* is unusable without resource reads and script execution, which harness `Skills` explicitly does not do.

### Strict docs build

- **mkdocstrings `paths` was misconfigured** — it pointed at the package directory rather than its parent, so griffe found nothing locally and silently fell back to a **stale, non-editable copy in site-packages**. The published API docs were documenting an outdated snapshot of the library. Verified end-to-end: `site/api/capability/index.html` now renders the `include`/`exclude` fields added in this PR, which are absent from the site-packages copy.
- **Bad cross-reference** — a docstring used the re-export alias path (`pydantic_ai_skills.SkillsCapability.from_spec`), whose *members* autorefs doesn't register. Now uses the canonical path, matching what `docs/api/capability.md` already used.
- **Root-absolute `/llms.txt` links** — these were also substantively wrong, not just noisy: the site uses `mike` versioning, so a root-absolute link escapes the version prefix. The files are plugin-generated and outside the mkdocs file registry, so a plain Markdown link trips `unrecognized_links` instead. Raw anchors keep the correct relative URL while leaving validation strict everywhere else.
- **Missing `installation.md`** — the nav referenced a page that didn't exist. Added it rather than deleting the entry, since `quick-start.md` jumps straight to writing a skill. The extras table is generated from `pyproject.toml` and verified to match exactly.

## Deliberate omissions

Two harness behaviors I chose **not** to copy, both of which are restrictions rather than capabilities:

- Requiring `name` to match the parent directory.
- Warning on unimplemented frontmatter fields — this only makes sense for an implementation that can't run scripts. We implement most of what it would warn about.

Happy to add either if you'd prefer parity.

## Reviewer notes

- The comparison table is built from harness source read on `main` today. Since it's **unreleased**, details may shift before it ships — worth re-checking at release.
- Worth a look at CI: if it installs the package non-editably before building docs, the same griffe fallback could have been masking API-doc drift for a while. Locally, `pip install -e .` keeps the installed copy from diverging again.

## Verification

- `pytest` — 472 passed
- `ruff check` / `ruff format --check` — clean
- `mkdocs build --strict` — exit 0, zero warnings
- All pre-commit hooks pass, including mypy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
