### PR TITLE
Rewrite README to be concise and link to the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,17 @@
 # pydantic-ai-skills
 
-A standardized, composable framework for building and managing Agent Skills within the Pydantic AI ecosystem.
-
-**Agent Skills** are modular collections of instructions, scripts, tools, and resources that enable AI agents to progressively discover, load, and execute specialized capabilities for domain-specific tasks.
-
-This package implements the [Agent Skills specification](https://agentskills.io/home) for Pydantic AI using a tool-calling approach, maintaining full compatibility with the specification while adapting the loading mechanism for Pydantic AI's architecture. Agent Skills is an open format maintained by Anthropic and open to contributions from the community.
-
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DougTrajano_pydantic-ai-skills&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DougTrajano_pydantic-ai-skills)
 
-## Features
+[Agent Skills](https://agentskills.io/home) for [Pydantic AI](https://ai.pydantic.dev/).
 
-- **Progressive Disclosure** - Load skill information only when needed, reducing token usage
-- **Agent Skills Spec** - Fully compatible with the [Agent Skills](https://agentskills.io/home) open format
-- **Filesystem Skills** - Define skills as filesystem directories with Markdown files and scripts
-- **Programmatic Skills** - Create skills dynamically in Python code using decorators or dataclasses
-- **Bundled Resources** - Agents read `REFERENCE.md`, `FORMS.md`, and other bundled files on demand
-- **Script Execution** - Agents run a skill's bundled scripts with named arguments
-- **Skill Registries** - Load skills from Git repositories, S3, or custom remote sources
-- **Skill Selection** - Expose a per-agent subset of your library with `include` / `exclude`
-- **Type-Safe** - Built with Python dataclasses and type hints
-- **Validation** - Automatic validation of skill metadata and structure
-- **Multiple Directories** - Load skills from multiple sources
-- **Security** - Path traversal prevention and safe script execution
+A skill is a folder with a `SKILL.md` file, optional reference docs, and optional scripts. Your agent
+sees only the name and description of each skill until it needs more, then loads the instructions,
+resources, and scripts on demand — keeping context small while the library grows.
 
-Full documentation available at: [https://dougtrajano.github.io/pydantic-ai-skills](https://dougtrajano.github.io/pydantic-ai-skills)
+📖 **[Full documentation](https://dougtrajano.github.io/pydantic-ai-skills)** — including
+[video tutorials](https://dougtrajano.github.io/pydantic-ai-skills/quick-start/#video-tutorials).
 
 ## Installation
 
@@ -33,205 +19,52 @@ Full documentation available at: [https://dougtrajano.github.io/pydantic-ai-skil
 pip install pydantic-ai-skills
 ```
 
-For development:
-
-```bash
-pip install pydantic-ai-skills[test]  # Includes pytest and coverage tools
-```
-
-## Video Tutorials
-
-Learn how to use pydantic-ai-skills through these video tutorials:
-
-### Basic Usage
-
-Get started with your first skill and agent:
-
-<video controls style="max-width:100%; border-radius:8px">
-  <source src="docs/assets/basic_usage.mp4" type="video/mp4">
-</video>
-
-### Advanced Usage
-
-Master advanced integration patterns:
-
-<video controls style="max-width:100%; border-radius:8px">
-  <source src="docs/assets/advanced_usage.mp4" type="video/mp4">
-</video>
-
-### Programmatic Skills
-
-Create dynamic skills with Python:
-
-<video controls style="max-width:100%; border-radius:8px">
-  <source src="docs/assets/programmatic_skills.mp4" type="video/mp4">
-</video>
-
 ## Quick Start
 
-We recommend using `SkillsCapability`, which is based on the Pydantic AI [Capabilities API](https://ai.pydantic.dev/capabilities/). It bundles the skills tools and instructions into a single object that can be added to agents. This provides a more streamlined and integrated way to use agent skills.
+Point a `SkillsCapability` at one or more skill directories and add it to your agent:
 
 ```python
 from pydantic_ai import Agent
 from pydantic_ai_skills import SkillsCapability
 
-agent = Agent(
-  model='gateway/openai:gpt-5.2',
-  instructions='You are a helpful research assistant.',
-  capabilities=[SkillsCapability(directories=['./skills'])],
-)
-```
-
-Alternatively, use `SkillsToolset` directly when your app is built around `toolsets=[...]`.
-
-```python
-from pydantic_ai import Agent
-from pydantic_ai_skills import SkillsToolset
-
-# Initialize Skills Toolset with one or more skill directories
-skills_toolset = SkillsToolset(directories=["./skills"])
-
-# Create agent with skills as a toolset
 agent = Agent(
     model='gateway/openai:gpt-5.2',
     instructions='You are a helpful research assistant.',
-    toolsets=[skills_toolset]
+    capabilities=[SkillsCapability(directories=['./skills'])],
 )
 
-# Use agent - skills tools are available for the agent to call
-user_prompt = "What are the last 3 papers on arXiv about machine learning?"
-
-nodes = []
-async with agent.iter(user_prompt) as agent_run:
-    async for node in agent_run:
-        nodes.append(node)
-        print(node)
+result = await agent.run('What are the last 3 papers on arXiv about machine learning?')
+print(result.output)
 ```
 
-**Output:**
-
-````python
-UserPromptNode(user_prompt='What are the last 3 papers on arXiv about machine learning?', instructions_functions=[], system_prompts=('You are a helpful research assistant.',), system_prompt_functions=[SystemPromptRunner(function=<function add_skills_to_system_prompt at 0x110e951c0>, dynamic=False, _takes_ctx=False, _is_async=False)], system_prompt_dynamic_functions={})
-ModelRequestNode(request=ModelRequest(parts=[SystemPromptPart(content='You are a helpful research assistant.', timestamp=datetime.datetime(2025, 12, 18, 23, 27, 16, 616893, tzinfo=datetime.timezone.utc)), SystemPromptPart(content="# Skills\n\nYou have access to skills that extend your capabilities. Skills are modular packages\ncontaining instructions, resources, and scripts for specialized tasks.\n\n## Available Skills\n\nThe following skills are available to you. Use them when relevant to the task:\n\n- **arxiv-search**: Search arXiv preprint repository for papers in physics, mathematics, computer science, quantitative biology, and related fields.\n- **pydanticai-docs**: Use this skill for requests related to Pydantic AI framework - building agents, tools, dependencies, structured outputs, and model integrations.\n- **web-research**: Use this skill for requests related to web research; it provides a structured approach to conducting comprehensive web research.\n## How to Use Skills\n\n**Progressive disclosure**: Load skill information only when needed.\n\n1. **When a skill is relevant to the current task**: Use `load_skill(skill_name)` to read the full instructions.\n2. **For additional documentation**: Use `read_skill_resource(skill_name, resource_name)` to read FORMS.md, REFERENCE.md, or other resources.\n3. **To execute skill scripts**: Use `run_skill_script(skill_name, script_name, args)` with appropriate command-line arguments.\n\n**Best practices**:\n- Select skills based on task relevance and descriptions listed above\n- Use progressive disclosure: load only what you need, when you need it, starting with load_skill\n- Follow the skill's documented usage patterns and examples\n", timestamp=datetime.datetime(2025, 12, 18, 23, 27, 16, 617375, tzinfo=datetime.timezone.utc)), UserPromptPart(content='What are the last 3 papers on arXiv about machine learning?', timestamp=datetime.datetime(2025, 12, 18, 23, 27, 16, 617384, tzinfo=datetime.timezone.utc))]))
-CallToolsNode(model_response=ModelResponse(parts=[ToolCallPart(tool_name='load_skill', args='{"skill_name":"arxiv-search"}', tool_call_id='call_WGBvmGWJQvOliYoG5AeP6BMh')], usage=RequestUsage(input_tokens=717, output_tokens=17, details={'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}), model_name='gpt-4o-2024-08-06', timestamp=datetime.datetime(2025, 12, 18, 23, 27, 16, tzinfo=TzInfo(0)), provider_name='openai', provider_details={'finish_reason': 'tool_calls'}, provider_response_id='chatcmpl-CoHgqj5YugHHE2ZJvnQtXx3U74Uib', finish_reason='tool_call'))
-ModelRequestNode(request=ModelRequest(parts=[ToolReturnPart(tool_name='load_skill', content='# Skill: arxiv-search\n**Description:** Search arXiv preprint repository for papers in physics, mathematics, computer science, quantitative biology, and related fields.\n**Path:** /Users/dougtrajano/Library/CloudStorage/OneDrive-Personal/dev/vscode/macbook/GitHub/pydantic-ai-skills/examples/skills/arxiv-search\n\n**Available Scripts:**\n- scripts/arxiv_search.py\n\n---\n\n# arXiv Search Skill\n\nThis skill provides access to arXiv, a free distribution service and open-access archive for scholarly articles in physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering, systems science, and economics.\n\n## When to Use This Skill\n\nUse this skill when you need to:\n\n- Find preprints and recent research papers before journal publication\n- Search for papers in computational biology, bioinformatics, or systems biology\n- Access mathematical or statistical methods papers relevant to biology\n- Find machine learning papers applied to biological problems\n- Get the latest research that may not yet be in PubMed\n\n## Skill Scripts\n\n### scripts/arxiv_search.py\n\nThe `scripts/arxiv_search.py` script accepts the following arguments:\n\n- `--query` (required): Search query string (e.g., "neural networks protein structure", "single cell RNA-seq")\n- `--max-papers` (optional): Maximum number of papers to retrieve (default: 10)\n\n### Usage Pattern\n\nUse the `run_skill_script` tool to execute the `scripts/arxiv_search.py` script. For example:\n\n```python\nrun_skill_script(\n    skill_name="arxiv-search",\n    script_name="scripts/arxiv_search.py",\n    args={"query": "your search query", "max-papers": 5}\n)\n```\n\nSearch for computational biology papers (default 10 results):\n\n```python\nrun_skill_script(\n    skill_name="arxiv-search",\n    script_name="scripts/arxiv_search.py",\n    args={"query": "protein folding prediction"}\n)\n```\n\n## Output Format\n\nThe script returns formatted results with:\n\n- **Title**: Paper title\n- **Summary**: Abstract/summary text\n- **URL**: Direct link to the paper on arXiv\n\nEach paper is separated by blank lines for readability.\n\n## Features\n\n- **Relevance sorting**: Results ordered by relevance to query\n- **Fast retrieval**: Direct API access with no authentication required\n- **Simple interface**: Clean, easy-to-parse output\n- **No API key required**: Free access to arXiv database\n\n## Dependencies\n\nThis skill requires the `arxiv` Python package. If not installed, you\'ll see an error message.\n\nTo install the package:\n\n```bash\npip install arxiv\n```\n\nThe package is not included by default since it\'s skill-specific. Install it when you first use this skill.\n\n## Notes\n\n- arXiv is particularly strong for:\n  - Computer science (cs.LG, cs.AI, cs.CV)\n  - Quantitative biology (q-bio)\n  - Statistics (stat.ML)\n  - Physics and mathematics\n- Papers are preprints and may not be peer-reviewed\n- Results include both recent uploads and older papers\n- Best for computational/theoretical work in biology', tool_call_id='call_WGBvmGWJQvOliYoG5AeP6BMh', timestamp=datetime.datetime(2025, 12, 18, 23, 27, 17, 430875, tzinfo=datetime.timezone.utc))]))
-CallToolsNode(model_response=ModelResponse(parts=[ToolCallPart(tool_name='run_skill_script', args='{"skill_name":"arxiv-search","script_name":"scripts/arxiv_search.py","args":{"query":"machine learning","max-papers":3}}', tool_call_id='call_oDXHSlx4bpoV3Frm8fvWU8j4')], usage=RequestUsage(input_tokens=1395, output_tokens=38, details={'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}), model_name='gpt-4o-2024-08-06', timestamp=datetime.datetime(2025, 12, 18, 23, 27, 17, tzinfo=TzInfo(0)), provider_name='openai', provider_details={'finish_reason': 'tool_calls'}, provider_response_id='chatcmpl-CoHgraqy3S9OKCsFIP0Y3c1Sg6tqC', finish_reason='tool_call'))
-ModelRequestNode(request=ModelRequest(parts=[ToolReturnPart(tool_name='run_skill_script', content='Title: Changing Data Sources in the Age of Machine Learning for Official Statistics\nSummary: Data science has become increasingly essential for the production of official statistics, as it enables the automated collection, processing, and analysis of large amounts of data. With such data science practices in place, it enables more timely, more insightful and more flexible reporting. However, the quality and integrity of data-science-driven statistics rely on the accuracy and reliability of the data sources and the machine learning techniques that support them. In particular, changes in data sources are inevitable to occur and pose significant risks that are crucial to address in the context of machine learning for official statistics.\n  This paper gives an overview of the main risks, liabilities, and uncertainties associated with changing data sources in the context of machine learning for official statistics. We provide a checklist of the most prevalent origins and causes of changing data sources; not only on a technical level but also regarding ownership, ethics, regulation, and public perception. Next, we highlight the repercussions of changing data sources on statistical reporting. These include technical effects such as concept drift, bias, availability, validity, accuracy and completeness, but also the neutrality and potential discontinuation of the statistical offering. We offer a few important precautionary measures, such as enhancing robustness in both data sourcing and statistical techniques, and thorough monitoring. In doing so, machine learning-based official statistics can maintain integrity, reliability, consistency, and relevance in policy-making, decision-making, and public discourse.\nURL: http://arxiv.org/abs/2306.04338v1\n\nTitle: DOME: Recommendations for supervised machine learning validation in biology\nSummary: Modern biology frequently relies on machine learning to provide predictions and improve decision processes. There have been recent calls for more scrutiny on machine learning performance and possible limitations. Here we present a set of community-wide recommendations aiming to help establish standards of supervised machine learning validation in biology. Adopting a structured methods description for machine learning based on data, optimization, model, evaluation (DOME) will aim to help both reviewers and readers to better understand and assess the performance and limitations of a method or outcome. The recommendations are formulated as questions to anyone wishing to pursue implementation of a machine learning algorithm. Answers to these questions can be easily included in the supplementary material of published papers.\nURL: http://arxiv.org/abs/2006.16189v4\n\nTitle: Learning Curves for Decision Making in Supervised Machine Learning: A Survey\nSummary: Learning curves are a concept from social sciences that has been adopted in the context of machine learning to assess the performance of a learning algorithm with respect to a certain resource, e.g., the number of training examples or the number of training iterations. Learning curves have important applications in several machine learning contexts, most notably in data acquisition, early stopping of model training, and model selection. For instance, learning curves can be used to model the performance of the combination of an algorithm and its hyperparameter configuration, providing insights into their potential suitability at an early stage and often expediting the algorithm selection process. Various learning curve models have been proposed to use learning curves for decision making. Some of these models answer the binary decision question of whether a given algorithm at a certain budget will outperform a certain reference performance, whereas more complex models predict the entire learning curve of an algorithm. We contribute a framework that categorises learning curve approaches using three criteria: the decision-making situation they address, the intrinsic learning curve question they answer and the type of resources they use. We survey papers from the literature and classify them into this framework.\nURL: http://arxiv.org/abs/2201.12150v2', tool_call_id='call_oDXHSlx4bpoV3Frm8fvWU8j4', timestamp=datetime.datetime(2025, 12, 18, 23, 27, 18, 930364, tzinfo=datetime.timezone.utc))]))
-CallToolsNode(model_response=ModelResponse(parts=[TextPart(content='Here are the last three papers from arXiv about machine learning:\n\n1. **Title:** Changing Data Sources in the Age of Machine Learning for Official Statistics\n   - **Summary:** This paper discusses the increasing importance of data science in official statistics production, highlighting risks and uncertainties related to changing data sources in machine learning contexts. It covers issues like concept drift, bias, and data validity, and offers measures to maintain the reliability and integrity of machine learning-based statistics.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2306.04338v1)\n\n2. **Title:** DOME: Recommendations for supervised machine learning validation in biology\n   - **Summary:** The paper provides a set of community-wide recommendations for machine learning validation in biology, emphasizing the importance of a structured methods description using DOME (data, optimization, model, evaluation). These guidelines aim to improve the scrutiny of machine learning performance and facilitate better understanding and assessment of methods.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2006.16189v4)\n\n3. **Title:** Learning Curves for Decision Making in Supervised Machine Learning: A Survey\n   - **Summary:** This survey covers the concept of learning curves in machine learning, which assess algorithm performance concerning resources like training examples. The paper categorizes learning curve approaches based on decision-making situations, and it surveys literature to classify various models within this framework.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2201.12150v2)')], usage=RequestUsage(input_tokens=2177, cache_read_tokens=1408, output_tokens=322, details={'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}), model_name='gpt-4o-2024-08-06', timestamp=datetime.datetime(2025, 12, 18, 23, 27, 19, tzinfo=TzInfo(0)), provider_name='openai', provider_details={'finish_reason': 'stop'}, provider_response_id='chatcmpl-CoHgtHBD9LUsRKbILVar99GtAGKHM', finish_reason='stop'))
-End(data=FinalResult(output='Here are the last three papers from arXiv about machine learning:\n\n1. **Title:** Changing Data Sources in the Age of Machine Learning for Official Statistics\n   - **Summary:** This paper discusses the increasing importance of data science in official statistics production, highlighting risks and uncertainties related to changing data sources in machine learning contexts. It covers issues like concept drift, bias, and data validity, and offers measures to maintain the reliability and integrity of machine learning-based statistics.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2306.04338v1)\n\n2. **Title:** DOME: Recommendations for supervised machine learning validation in biology\n   - **Summary:** The paper provides a set of community-wide recommendations for machine learning validation in biology, emphasizing the importance of a structured methods description using DOME (data, optimization, model, evaluation). These guidelines aim to improve the scrutiny of machine learning performance and facilitate better understanding and assessment of methods.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2006.16189v4)\n\n3. **Title:** Learning Curves for Decision Making in Supervised Machine Learning: A Survey\n   - **Summary:** This survey covers the concept of learning curves in machine learning, which assess algorithm performance concerning resources like training examples. The paper categorizes learning curve approaches based on decision-making situations, and it surveys literature to classify various models within this framework.\n   - **URL:** [Link to Paper](http://arxiv.org/abs/2201.12150v2)'))
-````
-
-## Choosing Which Skills to Expose
-
-One skill library can serve several agents. Use `include` or `exclude` to give each agent
-only the skills it should see:
+`SkillsToolset` is the same thing as a toolset, for agents built around `toolsets=[...]`:
 
 ```python
-from pydantic_ai_skills import SkillsCapability
+from pydantic_ai_skills import SkillsToolset
 
-research = SkillsCapability(directories=['./skills'], include=['arxiv-search', 'web-research'])
-everything_else = SkillsCapability(directories=['./skills'], exclude=['arxiv-search'])
+agent = Agent(model='gateway/openai:gpt-5.2', toolsets=[SkillsToolset(directories=['./skills'])])
 ```
 
-| Configuration | Skills in the catalog |
+Both inject the skill catalog into the agent's instructions automatically and expose four tools:
+
+| Tool | Purpose |
 | --- | --- |
-| Neither option | All discovered skills |
-| `include=['a', 'b']` | Only `a` and `b` |
-| `include=[]` | No skills |
-| `exclude=['a', 'b']` | All except `a` and `b` |
+| `list_skills()` | List available skills (optional — the catalog is already in the prompt) |
+| `load_skill(name)` | Read a skill's full instructions |
+| `read_skill_resource(skill_name, resource_name)` | Read a bundled file such as `REFERENCE.md` |
+| `run_skill_script(skill_name, script_name, args)` | Run a bundled script with named arguments |
 
-`include` and `exclude` cannot be combined, and a name that matches no discovered skill raises
-`ValueError` at construction so typos surface immediately. Selection applies to every source —
-programmatic skills, directories, and registries — and is re-applied by `reload()`.
+See [Quick Start](https://dougtrajano.github.io/pydantic-ai-skills/quick-start/).
 
-Both options work on `SkillsToolset` too, and in declarative agent specs:
-
-```yaml
-capabilities:
-  - SkillsCapability:
-      directories: ['./skills']
-      include:
-        - arxiv-search
-```
-
-> Selection controls what the model sees in the catalog. It is not a filesystem permission or an
-> access-control boundary — see [Security](https://dougtrajano.github.io/pydantic-ai-skills/security/).
-
-## Why pydantic-ai-skills
-
-Pydantic AI's own [`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness) ships a
-`Skills` capability that maps each `SKILL.md` to a deferred core capability. It is a deliberately
-minimal reader: it loads frontmatter and the Markdown body, and explicitly
-[does not enumerate, read, or execute bundled files](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/skills).
-
-`pydantic-ai-skills` implements the full Agent Skills package, not just its instructions:
-
-| | `pydantic-ai-skills` | harness `Skills` |
-| --- | --- | --- |
-| Skill metadata catalog (level 1) | ✅ | ✅ |
-| Instructions on demand (level 2) | ✅ | ✅ |
-| Bundled resources, e.g. `REFERENCE.md` (level 3) | ✅ `read_skill_resource` | ❌ not loaded |
-| Bundled script execution | ✅ `run_skill_script` | ❌ not executed |
-| `include` / `exclude` selection | ✅ | ✅ |
-| Programmatic skills in Python | ✅ decorators and dataclasses | ❌ use core `Capability` |
-| Remote registries (Git, S3) | ✅ | ❌ |
-| Registry composition (combine, filter, prefix, rename) | ✅ | ❌ |
-| Reload skills without restarting | ✅ `reload()` / `auto_reload` | ❌ construction-time snapshot |
-| Recursive discovery | ✅ up to `max_depth` | ❌ immediate children only |
-| Path traversal and symlink containment | ✅ | ❌ explicitly not a boundary |
-| Per-tool restriction, e.g. disable scripts | ✅ `exclude_tools` | n/a |
-| Deferred loading via `load_capability` | ✅ `defer_loading=True` | ✅ always deferred |
-
-The practical difference is **level 3 of progressive disclosure**. A skill that ships a reference
-document or a script is a complete package; without resource reads and script execution, the model
-gets the instructions but cannot follow them. `pydantic-ai-skills` runs those skills as written —
-including the ones published in Anthropic's
-[skills repository](https://github.com/anthropics/skills).
-
-If you only need instruction text injected on demand and are already invested in the harness, its
-`Skills` capability is a fine, smaller dependency. Reach for `pydantic-ai-skills` when your skills
-have bundled files, come from a shared registry, are generated in Python, or change while the
-process is running.
-
-## Creating Skills
-
-Skills are filesystem-based directories with a `SKILL.md` file containing YAML frontmatter and Markdown instructions.
-
-### Basic Skill Structure
+## Anatomy of a Skill
 
 ```md
 my-skill/
-└── SKILL.md # Required: Main instructions and metadata
+├── SKILL.md      # Required: YAML frontmatter + Markdown instructions
+├── REFERENCE.md  # Optional: extra docs, read on demand
+├── scripts/      # Optional: executable scripts
+└── resources/    # Optional: templates, data files
 ```
-
-### Extended Skill Structure
-
-```md
-my-skill/
-├── SKILL.md # Required: Main instructions and metadata
-├── FORMS.md # Optional: Form-filling guides
-├── REFERENCE.md # Optional: Detailed API reference
-├── scripts/ # Optional: executable scripts
-│ ├── script1.py
-│ └── script2.sh
-└── resources/ # Optional: Additional files
-├── templates/
-└── data.json
-```
-
-> Supported filesystem-based scripts include Python (`.py`), shell scripts (`.sh`, `.bash`, `.zsh`, `.fish`), and Windows batch files (`.bat`, `.cmd`). Extensionless or custom-extension files are supported when they are executable (and typically include a shebang on Unix-like systems).
->
-> The `run_skill_script` tool accepts named command-line arguments via a dict-style mapping.
->
-> Interpreter selection order for `run_skill_script` is:
->
-> 1. Shebang line, when present and resolvable
-> 2. Extension-based fallback for compatibility
-> 3. Direct executable invocation fallback
->
-> For portability, prefer adding a shebang line (for example `#!/usr/bin/env python3`) and executable permissions when appropriate.
-
-### Minimal SKILL.md
 
 ```markdown
 ---
@@ -243,155 +76,62 @@ description: Brief description of what this skill does and when to use it
 
 ## When to Use This Skill
 
-Use this skill when you need to:
-
-- Do specific task A
-- Handle scenario B
-- Process data type C
+Use this skill when you need to...
 
 ## Instructions
 
 1. Step 1
 2. Step 2
-3. Step 3
 ```
 
-### Metadata Requirements
+`name` (max 64 chars, lowercase letters, numbers and hyphens) and `description` (max 1024 chars) are
+required; other frontmatter fields are yours to use. See
+[Creating Skills](https://dougtrajano.github.io/pydantic-ai-skills/creating-skills/).
 
-Following the [Agent Skills specification](https://agentskills.io/specification):
+## Beyond the Filesystem
 
-**Required fields:**
+- **[Programmatic skills](https://dougtrajano.github.io/pydantic-ai-skills/programmatic-skills/)** — define skills in Python with decorators or dataclasses.
+- **[Registries](https://dougtrajano.github.io/pydantic-ai-skills/registries/)** — load skills from Git repositories, S3, or custom sources, and compose them (combine, filter, prefix, rename).
+- **[Skill selection](https://dougtrajano.github.io/pydantic-ai-skills/advanced/#selecting-which-skills-to-expose)** — give each agent a subset of a shared library with `include` / `exclude`.
+- **[Advanced features](https://dougtrajano.github.io/pydantic-ai-skills/advanced/)** — `reload()` / `auto_reload`, `exclude_tools`, deferred loading, recursive discovery.
 
-- `name`: Skill identifier (max 64 chars, lowercase letters/numbers/hyphens only)
-- `description`: Brief description (max 1024 chars)
+## Why This and Not `pydantic-ai-harness`
 
-You can also include optional fields to help you manage and categorize skills (`version`, `author`, `tags`, etc.). These are not used by the agent.
+The harness's own `Skills` capability is a minimal reader: it injects `SKILL.md` instructions but
+[does not enumerate, read, or execute bundled files](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/skills).
+`pydantic-ai-skills` implements the full package — bundled resources, script execution, remote
+registries, programmatic skills, and reload at runtime — so skills that ship a reference document or
+a script (including those in [Anthropic's skills repository](https://github.com/anthropics/skills))
+run as written. Feature-by-feature comparison:
+[Why pydantic-ai-skills](https://dougtrajano.github.io/pydantic-ai-skills/comparison/).
 
-**Validation:**
+## Security
 
-- ✅ Names must use lowercase letters, numbers, and hyphens only
-- ✅ Names cannot contain reserved words: "anthropic", "claude"
-- ✅ SKILL.md body should be under 500 lines (warning if exceeded)
-- ✅ Descriptions must be under 1024 characters
-
-## How Skills Work
-
-### Progressive Disclosure
-
-Skills implement **progressive disclosure** - loading information in stages:
-
-#### Level 1: Metadata (Always Loaded)
-
-- All skill names and descriptions are included in the system prompt
-- Enables skill discovery without tool calls
-- Minimal token overhead
-
-#### Level 2: Instructions (Loaded When Needed)
-
-- Agent calls `load_skill(name)` to read full instructions
-- Only loaded when skill is relevant to the task
-
-#### Level 3: Resources (Loaded As Needed)
-
-- Agent calls `read_skill_resource(skill_name, resource_name)` for additional docs
-- Only loaded when referenced or required
-
-### Tool-Calling Adaptation
-
-**Anthropic's Implementation:**
-
-- Claude uses `bash` commands to read files from filesystem
-- Skills exist as directories in a VM environment
-
-**Our Implementation:**
-
-- Uses tool-calling instead of bash commands
-- Skills are discovered and loaded via Pydantic AI tools
-- Maintains the same progressive disclosure pattern
-- Skills are structurally compatible with Anthropic's format
-
-## Available Tools
-
-The `SkillsToolset` provides four tools to agents:
-
-### 1. `list_skills()`
-
-List all available skills with descriptions, resources, and scripts.
-
-**Note:** With the enhanced system prompt, this tool is optional since all metadata is pre-loaded.
-
-### 2. `load_skill(name)`
-
-Load the full instructions for a specific skill.
-
-```python
-# Agent calls this when a skill is relevant
-result = await load_skill(ctx, "arxiv-search")
-```
-
-### 3. `read_skill_resource(skill_name, resource_name)`
-
-Read additional resource files (FORMS.md, REFERENCE.md, etc.).
-
-```python
-# Agent loads resources only when needed
-result = await read_skill_resource(ctx, "pdf-processing", "FORMS.md")
-```
-
-### 4. `run_skill_script(skill_name, script_name, args)`
-
-Execute a skill script with command-line arguments.
-
-```python
-# Agent executes scripts with arguments
-result = await run_skill_script(
-    ctx,
-    "arxiv-search",
-    "scripts/arxiv_search.py",
-    {"query": "machine learning", "max-papers": 5}
-)
-```
-
-## System Prompt
-
-The `SkillsToolset` automatically injects skill instructions into the agent's system prompt via the `get_instructions()` method. This includes:
-
-- All skill metadata (name + description) for discovery
-- Instructions on how to use skill tools effectively
-
-This follows the Agent Skills approach where all metadata is pre-loaded, enabling agents to select skills without calling `list_skills()`.
-
-The automatic injection happens when you add the toolset to an agent - no additional decorator is needed.
-
-## Security considerations
-
-We strongly recommend that you use Skills only from trusted sources: those you created yourself or obtained from trusted sources. Skills provide AI Agents with new capabilities through instructions and code, and while this makes them powerful, it also means a malicious Skill can direct agents to invoke tools or execute code in ways that don't match the Skill's stated purpose.
-
-> If you must use a Skill from an untrusted or unknown source, exercise extreme caution and thoroughly audit it before use. Depending on what access agents have when executing the Skill, malicious Skills could lead to data exfiltration, unauthorized system access, or other security risks.
+Only use skills from sources you trust. Skills give agents new capabilities through instructions and
+code, so a malicious skill can direct an agent to invoke tools or execute code in ways that don't
+match its stated purpose — with risks including data exfiltration and unauthorized system access.
+Audit any skill from an unknown source before use. See
+[Security & Deployment](https://dougtrajano.github.io/pydantic-ai-skills/security/).
 
 ## Related Resources
 
 - [Agent Skills Specification](https://agentskills.io/specification)
-- [Anthropic Agent Skills Documentation](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
-- [Anthropic Agent Skills Best Practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
-- [Pydantic AI Documentation](https://ai.pydantic.dev/)
+- [Anthropic Agent Skills docs](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) and [best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
 - [Agent Skills Cookbook](https://github.com/anthropics/claude-cookbooks/tree/main/skills)
-- [Introducing Agent Skills | Claude](https://www.claude.com/blog/skills)
-- [Using skills with Deep Agents](https://blog.langchain.com/using-skills-with-deep-agents/)
-- [vstorm-co/pydantic-deepagents](https://github.com/vstorm-co/pydantic-deepagents)
-
-## Acknowledgments
-
-- **Anthropic** - For creating and maintaining the [Agent Skills](https://agentskills.io/home) open format.
-- **Pydantic AI Team** - For the excellent agent framework.
-- **Community** - For feedback and contributions.
-
-> This project was highly inspired by [pydantic-deepagents](https://github.com/vstorm-co/pydantic-deepagents), which provided foundational ideas and patterns for agent skill implementation and progressive disclosure in the Pydantic AI. We gratefully acknowledge their work and contributions to the community.
+- [Pydantic AI Documentation](https://ai.pydantic.dev/)
 
 ## Contributing
 
-Contributions are welcome! Please see [Contributing - Pydantic AI - Agent Skills](https://dougtrajano.github.io/pydantic-ai-skills/contributing/).
+Contributions are welcome — see [Contributing](https://dougtrajano.github.io/pydantic-ai-skills/contributing/).
+
+## Acknowledgments
+
+Thanks to **Anthropic** for the [Agent Skills](https://agentskills.io/home) open format, the
+**Pydantic AI team** for the framework, and the **community** for feedback and contributions.
+
+This project was highly inspired by [pydantic-deepagents](https://github.com/vstorm-co/pydantic-deepagents),
+which provided foundational ideas and patterns for agent skills and progressive disclosure in Pydantic AI.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
+MIT License — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -13,11 +13,24 @@ resources, and scripts on demand — keeping context small while the library gro
 📖 **[Full documentation](https://dougtrajano.github.io/pydantic-ai-skills)** — including
 [video tutorials](https://dougtrajano.github.io/pydantic-ai-skills/quick-start/#video-tutorials).
 
+## Why This and Not `pydantic-ai-harness`
+
+The harness's own `Skills` capability is a minimal reader: it injects `SKILL.md` instructions but
+[does not enumerate, read, or execute bundled files](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/skills).
+`pydantic-ai-skills` implements the full package — bundled resources, script execution, remote
+registries, programmatic skills, and reload at runtime — so skills that ship a reference document or
+a script (including those in [Anthropic's skills repository](https://github.com/anthropics/skills))
+run as written. Feature-by-feature comparison:
+[Why pydantic-ai-skills](https://dougtrajano.github.io/pydantic-ai-skills/comparison/).
+
 ## Installation
 
 ```bash
-pip install pydantic-ai-skills
+uv add pydantic-ai-skills
 ```
+
+Millennials may continue to use `pip install pydantic-ai-skills`. It still works, like your Spotify
+playlist from 2013.
 
 ## Quick Start
 
@@ -94,16 +107,6 @@ required; other frontmatter fields are yours to use. See
 - **[Registries](https://dougtrajano.github.io/pydantic-ai-skills/registries/)** — load skills from Git repositories, S3, or custom sources, and compose them (combine, filter, prefix, rename).
 - **[Skill selection](https://dougtrajano.github.io/pydantic-ai-skills/advanced/#selecting-which-skills-to-expose)** — give each agent a subset of a shared library with `include` / `exclude`.
 - **[Advanced features](https://dougtrajano.github.io/pydantic-ai-skills/advanced/)** — `reload()` / `auto_reload`, `exclude_tools`, deferred loading, recursive discovery.
-
-## Why This and Not `pydantic-ai-harness`
-
-The harness's own `Skills` capability is a minimal reader: it injects `SKILL.md` instructions but
-[does not enumerate, read, or execute bundled files](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/skills).
-`pydantic-ai-skills` implements the full package — bundled resources, script execution, remote
-registries, programmatic skills, and reload at runtime — so skills that ship a reference document or
-a script (including those in [Anthropic's skills repository](https://github.com/anthropics/skills))
-run as written. Feature-by-feature comparison:
-[Why pydantic-ai-skills](https://dougtrajano.github.io/pydantic-ai-skills/comparison/).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@
 
 [Agent Skills](https://agentskills.io/home) for [Pydantic AI](https://ai.pydantic.dev/).
 
-A skill is a folder with a `SKILL.md` file, optional reference docs, and optional scripts. Your agent
-sees only the name and description of each skill until it needs more, then loads the instructions,
-resources, and scripts on demand — keeping context small while the library grows.
+**Agent Skills** are modular packages of instructions, resources, and scripts that teach an agent to
+handle a specialized task. On disk, a skill is just a folder: a `SKILL.md` file holding a name, a
+description, and Markdown instructions, plus any reference documents and executable scripts the task
+needs.
+
+Your agent starts out seeing only the name and description of each skill. When a task calls for one,
+it loads that skill's full instructions, and reads a reference document or runs a script only if it
+actually needs to. This is *progressive disclosure*: your skill library can grow without every skill
+paying for space in the prompt.
 
 📖 **[Full documentation](https://dougtrajano.github.io/pydantic-ai-skills)** — including
 [video tutorials](https://dougtrajano.github.io/pydantic-ai-skills/quick-start/#video-tutorials).


### PR DESCRIPTION
## What changed

The README had grown to 397 lines, most of it duplicating the docs site or padding. Rewritten down to **137 lines**.

- **Removed the serialized agent-run trace** — a 10-line dump of `UserPromptNode` / `ModelRequestNode` / `CallToolsNode` reprs that was roughly 60% of the file's bulk. Replaced with a three-line `agent.run()` example.
- **Merged three overlapping sections** — the Features bullet list, "How Skills Work", and "Available Tools" all described the same four tools and progressive disclosure. Now one tool table plus a "Beyond the Filesystem" section linking to the relevant docs page for each area.
- **Condensed the harness comparison** from a 14-row table to a short paragraph pointing at `docs/comparison.md`, which already carries the full table.
- **Dropped the `<video>` tags** — the relative `docs/assets/*.mp4` sources don't play on GitHub. Now a link to the Quick Start videos on the docs site, where they do work.
- **Moved duplicated reference material to links** — metadata validation rules, script interpreter selection order, progressive-disclosure levels, and system-prompt injection details all live in the docs already. This follows the "Link, Do Not Duplicate" rule in `CLAUDE.md`.

Unchanged: badges, installation, both integration paths (`SkillsCapability` and `SkillsToolset`), skill anatomy, the security warning, acknowledgments, and license.

## Why

`CLAUDE.md` asks the README to link to the docs site rather than restate it. The README was doing the opposite, and the parts it restated had started to drift from `docs/`.

## Reviewer notes

- Docs-only change; no code touched, so no test impact.
- All docs-site anchors in the new README were verified against the actual headings — notably `quick-start/#video-tutorials` (the videos are on Quick Start, not the index) and `advanced/#selecting-which-skills-to-expose`.
- New structure: what it is → install → quick start → skill anatomy → beyond the filesystem → why not the harness → security → resources → contributing/license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)