### PR TITLE
docs: add project description to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+**pydantic-ai-skills** is a Python library that implements the full [Agent Skills specification](https://agentskills.io/home) for [Pydantic AI](https://ai.pydantic.dev/) — enabling modular skill discovery, bundled resources, script execution, remote registries, and runtime reload for AI agents.
+
 This file provides guidance to coding agents (Claude Code, etc.) when working with code in this repository. `CLAUDE.md` is a symlink to this file — edit this one.
 
 ## Scope


### PR DESCRIPTION
## Summary

Add a concise one-line project description to the top of AGENTS.md that explains what pydantic-ai-skills does before diving into the file's purpose.

## Changes

- Added project description introducing pydantic-ai-skills and its core features
- Placed before the agent guidance section for better orientation

## Testing

This is a documentation-only change.

🤖 Generated with Claude Code