### PR TITLE
chore: upstream watch 2026-08-01 (no changes needed)

### DIFF
--- a/.github/upstream-watch.md
+++ b/.github/upstream-watch.md
@@ -1,0 +1,14 @@
+# Upstream Watch Log
+
+Tracks the last `pydantic-ai` / `pydantic-ai-harness` releases reviewed by the weekly
+upstream-watch routine. Newest entry first. The top entry's tags are the lower bound
+for the next run.
+
+## 2026-08-01
+
+- **pydantic/pydantic-ai**: checked through `v2.22.0` (published 2026-08-01T02:27:00Z)
+- **pydantic/pydantic-ai-harness**: checked through `v0.15.0` (published 2026-08-01)
+- **Verdict**: No action needed. Nothing in this window changes the private symbols this
+  package imports (`pydantic_ai._function_schema`, `pydantic_ai._griffe`, `pydantic_ai._utils`)
+  or the public `AbstractToolset` / `AbstractCapability` / `RunContext` / tool-registration
+  surface this package depends on. See the corresponding PR for full triage notes.


### PR DESCRIPTION
## Summary

Weekly upstream watch. No `.github/upstream-watch.md` existed yet, so the review window was the last 7 days.

## Releases reviewed

**[pydantic/pydantic-ai](https://github.com/pydantic/pydantic-ai/releases)**

| Tag | Published | Verdict |
| --- | --- | --- |
| [v2.19.0](https://github.com/pydantic/pydantic-ai/releases/tag/v2.19.0) | 2026-07-28 | `ModelHTTPError` headers/retry_after, cancellation fix, FastMCP dep range. No overlap. |
| [v2.20.0](https://github.com/pydantic/pydantic-ai/releases/tag/v2.20.0) | 2026-07-29 | New model support, usage/serialization bug fixes. No overlap. |
| [v2.21.0](https://github.com/pydantic/pydantic-ai/releases/tag/v2.21.0) | 2026-07-30 | `UsageLimits.per_request_input_tokens_limit`, `KnownModelName` refresh. No overlap. |
| [v2.22.0](https://github.com/pydantic/pydantic-ai/releases/tag/v2.22.0) | 2026-08-01 | See below — one item investigated in depth, concluded no code change needed. |

`v2.22.0` adds `RunContext.is_tool_available(tool: str | ToolDefinition) -> bool` ([#7011](https://github.com/pydantic/pydantic-ai/pull/7011)) and, as part of the same PR, fixes a disagreement between `available_tool_names` and the wire-side builders for **loaded capabilities with deferred member tools** — exactly the shape `SkillsCapability(defer_loading=True)` uses. This package doesn't reimplement or work around that visibility logic anywhere (checked `pydantic_ai_skills/toolset.py` and `capability.py` — no references to `available_tool_names` or tool-search internals), so the fix is a pure upstream improvement with nothing to change here. `is_tool_available` itself isn't something this package's tool functions currently need (`list_skills`, `load_skill`, `read_skill_resource`, `run_skill_script` don't do availability checks), and adopting it would require feature-detecting against the `pydantic-ai-slim>=1.105` floor for a capability we don't use yet — not justified by a real problem, per `AGENTS.md`'s "don't design for hypothetical future requirements."

Also checked: no changes in this window to `pydantic_ai._function_schema`, `pydantic_ai._griffe`, or `pydantic_ai._utils` (confirmed via commit history — `_function_schema.py` last touched 2026-07-16, `_griffe.py` untouched, `_utils.py`'s `is_async_callable`/`run_in_executor` unchanged in signature) — `tests/test_pydantic_ai_compat.py` needs no updates. No changes to `AbstractToolset`/`AbstractCapability`/tool-registration APIs.

**[pydantic/pydantic-ai-harness](https://github.com/pydantic/pydantic-ai-harness/releases)**

| Tag | Published | Verdict |
| --- | --- | --- |
| [v0.11.0](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.11.0) | 2026-07-24/25 | Monty upgrade, typechecking exclusion. No overlap. |
| [v0.12.0](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.12.0) | ~2026-07-26/27 | Shipped a new `Skills` capability (`pydantic_ai_harness.skills.Skills`) — SKILL.md-only, always-deferred, no bundled resources/scripts. |
| [v0.13.0](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.13.0) | 2026-07-28 | Capability renames (`SlidingWindow`→`SlidingWindowCompaction`, `LimitWarner`→`WarnNearLimits`) — doesn't touch `skills/`. Not our dependency. |
| [v0.14.0](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.14.0) | 2026-07-30 | MongoDB backend, docs. No overlap. |
| [v0.15.0](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.15.0) | 2026-08-01 | `ToolGuard`, StackOne capability, planning/memory changes. No overlap. |

`pydantic-ai-harness` isn't a dependency of this package, but `docs/comparison.md` documents its `Skills` capability for users choosing between the two. Verified the harness `Skills` PR ([#396](https://github.com/pydantic/pydantic-ai-harness/pull/396)) and the follow-up description-length-warning PR ([#466](https://github.com/pydantic/pydantic-ai-harness/pull/466)) against the existing comparison table — the doc (added 2026-07-25, same day as the harness release) is already accurate: SKILL.md-only, no bundled resources, always deferred, immediate-children-only discovery, include/exclude supported. No doc update needed.

## What changed

- Added `.github/upstream-watch.md` recording the tags checked this run, for the next run's cutoff. No other files touched — nothing in the reviewed releases warranted a code change.

## Verification

- `pip install -e ".[test,git,s3,dev]"` — not run; the change is documentation-only (no Python files touched), so there's nothing for the test/lint suite to exercise differently. Ran it mentally against the diff: zero `.py` files changed.
- `pytest` — not run, same reasoning; no behavior changed.
- `pre-commit run --all-files` — not run in this environment for the same reason. If this PR is later given a mixed diff, this section will be updated with an actual run.

---
_Generated by [Claude Code](https://claude.ai/code/session_016WTHeG6UC5CjACNHrVYLBM)_