### PR TITLE
chore: upstream watch 2026-08-07 (no changes needed)

### DIFF
--- a/.github/upstream-watch.md
+++ b/.github/upstream-watch.md
@@ -4,6 +4,26 @@ Tracks the last `pydantic-ai` / `pydantic-ai-harness` releases reviewed by the w
 upstream-watch routine. Newest entry first. The top entry's tags are the lower bound
 for the next run.
 
+## 2026-08-07
+
+- **pydantic/pydantic-ai**: checked through `v2.26.0` (published 2026-08-06). Reviewed
+  `v2.23.0`–`v2.26.0`.
+- **pydantic/pydantic-ai-harness**: checked through `v0.18.0` (published 2026-08-05).
+  Reviewed `v0.17.0`–`v0.18.0`.
+- **Verdict**: No action needed. The two `AbstractCapability` bug fixes in `v2.23.0`
+  (capability container rebinding via `dataclasses.replace`, and `wrap_run_event_stream`
+  / node hooks now firing under `agent.iter()`) don't touch anything `SkillsCapability`
+  does — it's a plain dataclass (no custom `__init__` to break rebinding) and implements
+  none of the node/event-stream hooks. `v2.26.0`'s new tool-deferral machinery
+  (`ToolAvailabilityDeltaPart`, native per-provider deferral channels) is transparent to
+  us: `SkillsCapability` already used the existing `defer_loading`/`id` fields, and their
+  semantics are unchanged. `RunContext.cancel()` and `AgentRun.cancel()` are additive.
+  The private symbols this package imports (`pydantic_ai._function_schema`,
+  `pydantic_ai._griffe.doc_descriptions`, `pydantic_ai._utils.is_async_callable` /
+  `run_in_executor`) are unchanged. `pydantic-ai-harness` releases (browser-use agent
+  delegation, spend limits) are irrelevant — this package has no dependency on
+  `pydantic-ai-harness`. See the corresponding PR for full triage notes.
+
 ## 2026-08-01
 
 - **pydantic/pydantic-ai**: checked through `v2.22.0` (published 2026-08-01T02:27:00Z)


### PR DESCRIPTION
Weekly upstream-watch run. No action needed — this PR only updates the watch log.

## Releases reviewed

**pydantic/pydantic-ai** (cutoff: `v2.22.0`, checked through `v2.26.0`)

- [`v2.23.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.23.0) (2026-08-03) — Adds `cost`/`cost_limit`, `ToolAvailabilityDeltaPart` (native tool deferral), Bedrock/Gemini/Temporal fixes, and two `AbstractCapability` fixes: (1) preserve capability container subclasses during binding — `dataclasses.replace()` now uses a shallow-copy helper instead of reinvoking `__init__`, fixing `CombinedCapability`/`WrapperCapability` subclasses with custom constructors; (2) capability `wrap_run_event_stream` and node hooks (`before_node_run`, `wrap_node_run`, `after_node_run`, `on_node_run_error`) now fire consistently under `agent.iter()`, not just `agent.run()`.
  **Conclusion:** Not actionable. `SkillsCapability` ([pydantic_ai_skills/capability.py](../blob/main/pydantic_ai_skills/capability.py)) is a plain dataclass with only `__post_init__` (no custom `__init__` that `dataclasses.replace()` could break), and it implements none of `wrap_run_event_stream` or the node hooks — it only overrides `get_toolset`, `get_instructions`, `get_description`, and `from_spec`. Neither fix changes behavior we rely on.
- [`v2.24.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.24.0) (2026-08-04) — Model-provider bug fixes only (Google, Bedrock, Kimi, OpenRouter, Groq, Vercel AI, AG-UI). **Conclusion:** Not relevant, no imports touched.
- [`v2.25.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.25.0) (2026-08-05) — xAI FileSearchTool option, Azure/Mistral fix, `base_url`/`WrapperModel` fix, GPT-5.6 thinking fix, malformed tool-call arg handling. **Conclusion:** Not relevant.
- [`v2.26.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.26.0) (2026-08-06) — Tool-hiding/reveal via tool search, `load_capability`, `ToolReturn.tools`; first-party run cancellation (`AgentRun.cancel()`, `RunContext.cancel()`, `RunCancelled`); `run_stream_events()` promoted to public `AgentRunEvents`; DeepSeek V4 Flash support; assorted model-provider fixes.
  **Conclusion:** Not actionable. The new deferred-tool machinery is transparent to us — `SkillsCapability` already exposes the existing `id`/`defer_loading`/`description` fields from `AbstractCapability`, and this release doesn't change their semantics. `RunContext.cancel()` is purely additive and doesn't affect the `ctx: RunContext[Any]` signatures our tool functions use.

**pydantic/pydantic-ai-harness** (cutoff: `v0.15.0`, checked through `v0.18.0`)

- [`v0.17.0`](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.17.0) (2026-08-04) — Spend-limit capabilities, billing/media fixes.
- [`v0.18.0`](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.18.0) (2026-08-05) — Browser-use agent delegation for open-ended web tasks.
  **Conclusion:** Not relevant. This package has no dependency on `pydantic-ai-harness` (not in `pyproject.toml`, not imported anywhere).

## What changed

Only [.github/upstream-watch.md](../blob/main/.github/upstream-watch.md) — new dated entry recording the tags checked and the verdict above, per the routine's own convention.

No changes to `pydantic_ai_skills/` or `tests/`; the private symbols this package imports (`pydantic_ai._function_schema.FunctionSchema`/`function_schema`, `pydantic_ai._griffe.doc_descriptions`, `pydantic_ai._utils.is_async_callable`/`run_in_executor`) and the public `AbstractToolset`/`AbstractCapability`/`RunContext` surface are all still present and unchanged at current upstream tip, confirmed by inspecting the cloned `pydantic/pydantic-ai` source directly.

## Verification

Not run — this PR touches only a markdown log file (`.github/upstream-watch.md`), no `pydantic_ai_skills/` or `tests/` changes, so there is nothing for `pytest` or `pre-commit` to newly cover. `tests/test_pydantic_ai_compat.py` was manually cross-checked against current upstream `pydantic-ai` source (see above) rather than re-run, since the environment doesn't have the dev extras installed for this run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01URzik5hGUJNpiSDoA4xvXv)_