### PR TITLE
chore: upstream watch 2026-08-14 (no changes needed)

### DIFF
--- a/.github/upstream-watch.md
+++ b/.github/upstream-watch.md
@@ -4,6 +4,32 @@ Tracks the last `pydantic-ai` / `pydantic-ai-harness` releases reviewed by the w
 upstream-watch routine. Newest entry first. The top entry's tags are the lower bound
 for the next run.
 
+## 2026-08-14
+
+- **pydantic/pydantic-ai**: checked through `v2.30.0` (published 2026-08-13). Reviewed
+  `v2.27.0`–`v2.30.0`, plus the `v1` backport line `v1.107.2`–`v1.107.5`.
+- **pydantic/pydantic-ai-harness**: checked through `v0.20.0` (published 2026-08-13).
+  Reviewed `v0.18.1` and `v0.20.0`.
+- **Verdict**: No action needed. `v1.107.2`/`v2.27.1`/`v1.107.4`/`v2.28.0`/`v1.107.5`/`v2.30.0`
+  are security fixes to the local dev web chat UI (`Agent.to_web()`, `clai web`) and the
+  `web_fetch` tool's download size — this package doesn't wrap either. `v2.29.0`'s FastMCP
+  4 / MCP SDK v2 support in `MCPToolset` and new model providers (Snowflake, Crusoe, Azure
+  AI Voice Live) aren't used here. `v2.29.0`'s "include parameter descriptions in rendered
+  tool signatures" (#6487) only touches `function_signature.py` and `tools.py`, confirmed by
+  reading the PR's file list directly — `_griffe.py` and `doc_descriptions()`'s signature and
+  return shape are untouched, so `pydantic_ai_skills/toolset.py`'s
+  `doc_descriptions(f, sig, docstring_format='auto')` call keeps working as-is. `v2.30.0`'s
+  deferred-tool availability gate (#7271, #7442 — a fail-closed load→reveal→call ordering
+  enforced via `ModelRetry`) is explicitly documented upstream as non-breaking for
+  `AbstractCapability`/`AbstractToolset` implementers; `SkillsCapability` just forwards
+  `defer_loading`/`id` to the base class and implements no deferral logic of its own, so
+  nothing here depends on the old ordering. The private symbols this package imports
+  (`pydantic_ai._function_schema`, `pydantic_ai._griffe.doc_descriptions`,
+  `pydantic_ai._utils.is_async_callable` / `run_in_executor`) are unchanged.
+  `pydantic-ai-harness` releases (realtime speech support, compaction estimator tweaks) are
+  irrelevant — this package has no dependency on `pydantic-ai-harness`. See the corresponding
+  PR for full triage notes.
+
 ## 2026-08-07
 
 - **pydantic/pydantic-ai**: checked through `v2.26.0` (published 2026-08-06). Reviewed


### PR DESCRIPTION
## Summary

Weekly upstream watch. Cutoff was the previous entry in `.github/upstream-watch.md`: `pydantic-ai` through `v2.26.0` and `pydantic-ai-harness` through `v0.18.0` (both 2026-08-07). No code changes needed — this PR only updates the tracking log.

## Releases reviewed

### pydantic/pydantic-ai

| Tag | Link | Conclusion |
| --- | --- | --- |
| `v2.27.0` | https://github.com/pydantic/pydantic-ai/releases/tag/v2.27.0 | OTel serialization fixes, Snowflake provider, `xai_agent_count` setting, compaction round-trip fixes. Nothing touches this package's imports or the toolset/capability surface. |
| `v2.27.1` | https://github.com/pydantic/pydantic-ai/releases/tag/v2.27.1 | Security fix: retry-prompt content not redacted under `include_content=False` outside tool calls (GHSA-3gh4-cghq-f8v4). This package doesn't use `InstrumentationSettings`. Not applicable. |
| `v2.28.0` | https://github.com/pydantic/pydantic-ai/releases/tag/v2.28.0 | Security fix: dev web chat UI CSRF-style request (GHSA-h4xc-3qfq-jf93). Realtime speech, new provider. This package doesn't wrap `Agent.to_web()`/`clai web`. Not applicable. |
| `v2.29.0` | https://github.com/pydantic/pydantic-ai/releases/tag/v2.29.0 | FastMCP 4 / MCP SDK v2 support in `MCPToolset` (unused here), Azure AI Voice Live, gzip fix. Also includes PR [#6487](https://github.com/pydantic/pydantic-ai/pull/6487) "Include parameter descriptions in rendered tool signatures" — checked its full file list directly against a local clone; it only touches `function_signature.py`/`tools.py`/tests. `_griffe.py` is untouched, so `doc_descriptions()` (the private symbol this package imports and calls as `doc_descriptions(f, sig, docstring_format='auto')` in `toolset.py`) keeps its exact signature and return shape. |
| `v2.30.0` | https://github.com/pydantic/pydantic-ai/releases/tag/v2.30.0 | Security fix: DNS rebinding in dev web chat UI (GHSA-q2xc-rrxj-58x9), not applicable here. Also ships the deferred-tool availability gate (PR [#7271](https://github.com/pydantic/pydantic-ai/pull/7271), [#7442](https://github.com/pydantic/pydantic-ai/pull/7442)) enforcing a fail-closed load→reveal→call ordering for deferred capability tools. Upstream explicitly documents this as non-breaking: "Existing `defer_loading` configurations continue working; `AbstractCapability` and `AbstractToolset` interfaces are unchanged." `SkillsCapability` only forwards `defer_loading`/`id` to the base class and implements no deferral logic of its own, so nothing here depends on the previous ordering. |
| `v1.107.2`, `v1.107.4`, `v1.107.5` | (v1 backport line) | Same security fixes as `v2.27.1`/`v2.28.0`/`v2.30.0` backported to the `v1.x` line this package's floor (`pydantic-ai-slim>=1.105`) sits on. Same "not applicable" reasoning. |

### pydantic/pydantic-ai-harness

| Tag | Link | Conclusion |
| --- | --- | --- |
| `v0.18.1` | https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.18.1 | Deferred-tool visibility read fix, compaction estimator update. Irrelevant — this package has no dependency on `pydantic-ai-harness`. |
| `v0.20.0` | https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.20.0 | Realtime speech support, compaction cache-point ordering, build tooling pin. Irrelevant for the same reason. |

## What changed

Only `.github/upstream-watch.md`: appended a dated entry recording the tags checked (`pydantic-ai` through `v2.30.0`, `pydantic-ai-harness` through `v0.20.0`) and the verdict above, per the routine's own convention.

No changes to `pydantic_ai_skills/` or `tests/` — nothing in this window required them.

## Verification

No code changed, so the routine's step 6 checks (`pytest`, `pre-commit run --all-files`) don't apply to this diff — only a Markdown log file was touched. I did not run them for this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CnyknznybFUVKfE6fvyrFy)_