### PR TITLE
fix: derive release version from the git tag instead of pushing to main

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,39 +13,19 @@ jobs:
 
     permissions:
       id-token: write   # required for Trusted Publishing
-      contents: write   # required to commit version update
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.target_commitish }}  # checkout the target branch
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.release.tag_name }}  # build exactly what was tagged
+          fetch-depth: 0  # hatch-vcs derives the version from tags
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-
-      - name: Extract version from release tag
-        id: get_version
-        run: |
-          # Remove 'v' prefix if present (e.g., v1.0.0 -> 1.0.0)
-          VERSION=${GITHUB_REF#refs/tags/}
-          VERSION=${VERSION#v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Update version in pyproject.toml
-        run: |
-          sed -i 's/^version = ".*"/version = "${{ steps.get_version.outputs.version }}"/' pyproject.toml
-
-      - name: Commit version update
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          git commit -m "chore: bump version to ${{ steps.get_version.outputs.version }}"
-          git push
 
       - name: Install build backend
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "pydantic-ai-skills"
-version = "1.3.0"
+dynamic = ["version"]
 description = "A lightweight agent skill implementation for Pydantic AI"
 authors = [
     { name = "Douglas Trajano", email = "douglas.trajano@outlook.com" },
@@ -125,6 +125,12 @@ quote-style = "single"
 
 [tool.ruff.lint.per-file-ignores]
 "examples/**/*.py" = ["D101", "D103"]
+
+[tool.hatch.version]
+# Version comes from the git tag (e.g. 1.4.0) so releases never need a commit
+# back to main. fallback-version covers builds from a tarball with no git data.
+source = "vcs"
+fallback-version = "0.0.0"
 
 [tool.hatch.build.targets.wheel]
 packages = ["pydantic_ai_skills"]


### PR DESCRIPTION
## Why

The `Publish to PyPI` workflow rewrote `pyproject.toml` with `sed` and pushed the version bump directly to `main`. With the new branch ruleset in place, that push is rejected and the whole release fails:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Required status check "GitGuardian Security Checks" is expected.
```

## What changed

**`pyproject.toml`**
- Build requires `hatch-vcs` alongside `hatchling`.
- `version = "1.3.0"` → `dynamic = ["version"]`.
- New `[tool.hatch.version]` with `source = "vcs"` and `fallback-version = "0.0.0"` (covers builds from a tarball with no git metadata).

**`.github/workflows/pypi-publish.yml`**
- Removed the version-extraction, `sed`, and commit/push steps — the version now comes from the release tag at build time.
- `contents: write` → `contents: read`.
- Checkout uses `ref: github.event.release.tag_name` (builds exactly what was tagged rather than the branch tip) with `fetch-depth: 0` so hatch-vcs can see tags.

## Notes for the reviewer

- Verified locally: a clean checkout at a tag builds `pydantic_ai_skills-<tag>-py3-none-any.whl`. Existing tags are unprefixed (`1.4.0`); setuptools_scm also accepts a `v` prefix if that ever changes.
- The git tag becomes the single source of truth for the version — `pyproject.toml` on `main` no longer carries it.
- Dev installs now report versions like `1.4.1.dev0+gc9d7343` instead of a pinned number. Nothing in the package exports `__version__`, so no code changes were needed.
- Release `1.4.0` is already tagged, so re-running that release will publish `1.4.0` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)