### PR TITLE
chore: harden CI, add agent guardrails, and stop config drift

### DIFF
--- a/.claude/commands/upstream-watch.md
+++ b/.claude/commands/upstream-watch.md
@@ -1,0 +1,96 @@
+---
+description: Review pydantic-ai and pydantic-ai-harness releases published since the last watch entry, and record a verdict in .github/upstream-watch.md
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write, WebFetch
+---
+
+# Upstream watch
+
+This package wraps Pydantic AI and imports several of its **private** symbols, so an
+upstream release can break it without any change here. This routine is the standing
+review that catches that. It produces one entry in `.github/upstream-watch.md` and,
+when action is needed, the issue or PR that fixes it.
+
+Run it weekly, or on demand before a release.
+
+## 1. Establish the lower bound
+
+Read the **top entry** of `.github/upstream-watch.md`. Its two "checked through" tags are
+the lower bound for this run — you are reviewing everything published *after* them. Note
+today's date for the new entry heading.
+
+## 2. Collect the releases
+
+```bash
+gh release list --repo pydantic/pydantic-ai --limit 40
+gh release list --repo pydantic/pydantic-ai-harness --limit 20
+```
+
+Everything newer than the lower bound is in scope, **including the `v1.x` backport line** —
+`pyproject.toml` declares `pydantic-ai-slim>=1.105`, and CI tests against `1.105.0`, so a
+v1 backport that breaks the floor breaks a supported configuration.
+
+Read each release body with `gh release view <tag> --repo <repo>`. When a release note is
+ambiguous about what a PR actually touched, open the PR's file list rather than guessing —
+past entries in the log did exactly this, and it is what turned a scary-sounding release
+note into a confident "no action".
+
+## 3. Assess impact against what this package actually uses
+
+The surface that can break is narrow. Check each release against it specifically:
+
+- **Private imports** (the real risk — no deprecation policy protects these):
+  - `pydantic_ai._function_schema` → `FunctionSchema`, `function_schema`
+  - `pydantic_ai._griffe` → `doc_descriptions`, called in
+    [pydantic_ai_skills/toolset.py](../../pydantic_ai_skills/toolset.py) as
+    `doc_descriptions(f, sig, docstring_format='auto')` — verify the *signature and return
+    shape*, not just that the module still exists
+  - `pydantic_ai._utils` → `is_async_callable`, `run_in_executor`, used in
+    [pydantic_ai_skills/local.py](../../pydantic_ai_skills/local.py)
+  - `pydantic_ai.tools.GenerateToolJsonSchema` (public, but tracked alongside them)
+
+  [tests/test_pydantic_ai_compat.py](../../tests/test_pydantic_ai_compat.py) is the tripwire
+  for these. If a symbol moved, that test is what must be updated — keep it in sync with
+  what the code actually imports.
+
+- **`AbstractToolset` / `AbstractCapability`** — the base classes behind `SkillsToolset` and
+  `SkillsCapability`. Note that `SkillsCapability` is deliberately a thin delegating wrapper
+  that forwards to `SkillsToolset`; changes to capability *internals* usually don't reach it.
+
+- **Tool registration and `RunContext`** — every tool in `toolset.py` takes
+  `ctx: RunContext[Any]` first.
+
+Not in scope, and worth stating explicitly in the verdict so the next run doesn't re-triage
+it: model providers, the local dev web chat UI (`Agent.to_web()`, `clai web`), `web_fetch`,
+MCP client support, and anything in `pydantic-ai-harness` (this package does not depend on
+it — it is tracked only because upstream ships them together).
+
+## 4. Verify empirically when anything looks close
+
+Do not settle a real question by reading release notes alone:
+
+```bash
+uv pip install --system --upgrade pydantic-ai-slim && pytest
+uv pip install --system "pydantic-ai-slim==1.105.0" && pytest   # the declared floor
+```
+
+## 5. Record the entry
+
+Prepend a new `## YYYY-MM-DD` section to `.github/upstream-watch.md`, above the previous
+top entry, following the existing format exactly:
+
+- **pydantic/pydantic-ai**: checked through `<tag>` (published `<date>`), reviewed `<range>`
+- **pydantic/pydantic-ai-harness**: checked through `<tag>` (published `<date>`), reviewed `<range>`
+- **Verdict**: what you concluded and *why*, naming the specific releases, PR numbers, and
+  symbols you checked.
+
+Write the verdict so a future reader can tell whether you actually verified something or
+merely assumed it. A vague "no breaking changes" entry is worse than useless — it looks like
+coverage while providing none. Always close by confirming the private-symbol status.
+
+## 6. Open the PR
+
+Branch, commit the log entry, and open a PR. If the review found real impact, file the issue
+or include the fix, and reference it from the verdict.
+
+**Do not skip the entry when the verdict is "no action".** The log's value is the unbroken
+chain of lower bounds; a missing week silently widens the next run's range.

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,85 @@
+name: 🐛 Bug
+description: Report a bug or unexpected behavior in pydantic-ai-skills
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+
+        Please give us enough detail to reproduce the problem.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Initial checks
+      description: Just making sure we're on the same page.
+      options:
+        - label: I'm using the [latest version](https://github.com/dougtrajano/pydantic-ai-skills/releases/latest) of pydantic-ai-skills
+          required: true
+        - label: I've searched [the issue tracker](https://github.com/dougtrajano/pydantic-ai-skills/issues) for this issue before opening it
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What did you see, and what did you expect to see instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Minimal, reproducible example
+      description: >
+        A self-contained
+        [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)
+        makes this dramatically faster to fix.
+
+        (This is formatted as code automatically, so no backticks needed.)
+      placeholder: |
+        from pydantic_ai import Agent
+        from pydantic_ai_skills import SkillsToolset
+
+        ...
+      render: Python
+
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Traceback or logs
+      description: The full traceback, if there is one.
+      render: text
+
+  - type: input
+    id: skills-version
+    attributes:
+      label: pydantic-ai-skills version
+      placeholder: "1.4.0"
+    validations:
+      required: true
+
+  - type: input
+    id: pydantic-ai-version
+    attributes:
+      label: pydantic-ai-slim version
+      description: Output of `pip show pydantic-ai-slim | grep -i version`. This package supports >=1.105.
+      placeholder: "2.30.0"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12.8"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 15.6 / Ubuntu 24.04 / Windows 11"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Ask a question
+    url: https://github.com/dougtrajano/pydantic-ai-skills/discussions
+    about: Usage questions and open-ended discussion belong in Discussions.
+  - name: 📖 Documentation
+    url: https://dougtrajano.github.io/pydantic-ai-skills/
+    about: Concepts, guides, and the API reference.

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,44 @@
+name: 🚀 Feature request
+description: Suggest a new feature or improvement
+labels: ["feature"]
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Initial checks
+      options:
+        - label: I've searched [the issue tracker](https://github.com/dougtrajano/pydantic-ai-skills/issues) for this request before opening it
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that's hard or impossible today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Sketch the API if you have one in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, and why they fall short.
+
+  - type: checkboxes
+    id: spec
+    attributes:
+      label: Agent Skills specification
+      description: >
+        This package implements the [Agent Skills specification](https://agentskills.io/home).
+        Features that conflict with the spec are unlikely to be accepted.
+      options:
+        - label: I believe this is consistent with the Agent Skills specification (or the spec doesn't cover it)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,28 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # The `uv` ecosystem (not `pip`) is what keeps the committed uv.lock current.
+  # CI still installs unlocked from pyproject.toml on purpose: this is a library,
+  # so an upstream release that breaks us should surface immediately rather than
+  # waiting for a lockfile bump.
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      python-packages:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!-- Thanks for contributing to pydantic-ai-skills! -->
+
+<!-- Please read the contributing guide: https://dougtrajano.github.io/pydantic-ai-skills/contributing/ -->
+
+- Closes #<issue>
+
+## Summary
+
+<!-- What does this change and why? -->
+
+## Checklist
+
+- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
+- [ ] **Tests** added or updated for any behavior change (`pytest`).
+- [ ] `pre-commit run --all-files` passes.
+- [ ] Docs updated if behavior, configuration, or public API changed.
+- [ ] New code works against the **floor** (`pydantic-ai-slim>=1.105`, Python 3.10), not just the latest.
+- [ ] **PR title** is fit for the [release changelog](https://github.com/dougtrajano/pydantic-ai-skills/releases), and the PR is labelled `feature`, `bug`, `dependency`, `docs`, or `chore`.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+# Drives GitHub's "Generate release notes" button. Categories come from PR
+# labels, which is why the PR template asks for one of these to be applied.
+changelog:
+  exclude:
+    labels:
+      - docs
+      - chore
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 📦 Dependencies
+      labels:
+        - dependency
+    - title: 🔧 Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PRs cancel their own superseded runs. Pushes get a group keyed on run_id so
+  # one commit to main never cancels the run for the previous one.
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:
@@ -20,7 +25,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   test:
     name: Test (Python ${{ matrix.python-version }}, pydantic-ai ${{ matrix.pydantic-ai-version }})
@@ -39,7 +44,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Install dependencies
         run: uv pip install --system -e ".[test,git]"
@@ -79,3 +84,99 @@ jobs:
           name: pr-metadata-${{ github.run_id }}
           path: pr-metadata.env
           retention-days: 7
+
+  test-lowest-versions:
+    # Resolves every direct dependency to its declared floor (anyio>=4.0.0,
+    # pydantic-ai-slim>=1.105, pyyaml>=6.0) so a floor we no longer actually
+    # support fails here instead of in a user's environment.
+    name: Test lowest direct versions (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Install dependencies at their lowest declared versions
+        run: uv pip install --system --resolution lowest-direct -e ".[test,git]"
+
+      - name: Show resolved versions
+        run: uv pip freeze
+
+      - name: Run pytest
+        run: pytest --no-cov
+
+  build:
+    # Catches packaging breakage on the PR that causes it, rather than on
+    # release day when pypi-publish.yml runs the build for the first time.
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the version from the git tag history.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Check distribution metadata
+        run: uvx twine check --strict dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ github.run_id }}
+          path: dist/
+          retention-days: 7
+
+  docs:
+    # gh-pages.yml only builds on push to main, so without this a docs break
+    # is invisible until it has already been merged.
+    name: Build docs (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The git-revision-date-localized plugin needs full history.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[docs]"
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+  check:
+    # The single required status check for branch protection. Keeping the
+    # matrix job names out of branch protection means the matrix can change
+    # without a settings change, and a job that never runs still fails here.
+    name: Check
+    if: always()
+    needs: [lint, test, test-lowest-versions, build, docs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all jobs succeeded
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: pre-commit/action@v3.0.1
 
   test:
     name: Test (Python ${{ matrix.python-version }}, pydantic-ai ${{ matrix.pydantic-ai-version }})
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      - uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
         run: uv pip install --system -e ".[test,git]"
@@ -104,7 +104,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      - uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies at their lowest declared versions
         run: uv pip install --system --resolution lowest-direct -e ".[test,git]"
@@ -130,7 +130,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      - uses: astral-sh/setup-uv@v5
 
       - name: Build sdist and wheel
         run: uv build
@@ -159,7 +159,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      - uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
         run: uv pip install --system -e ".[docs]"
@@ -177,6 +177,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs succeeded
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,47 @@
+name: Link Check
+
+# Catches links that rot without anyone touching the file they live in — the
+# dead CODE_OF_CONDUCT.md link in docs/contributing.md sat there unnoticed
+# precisely because nothing ever re-checked it.
+
+on:
+  schedule:
+    # Mondays, 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: link-check
+  cancel-in-progress: true
+
+jobs:
+  link-check:
+    name: Check links
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed by create-issue-from-file below.
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+        with:
+          args: "--config lychee.toml --no-progress './**/*.md'"
+          output: lychee/out.md
+          # Report through an issue rather than a red scheduled run, which
+          # nobody sees. The step's exit code is read below instead.
+          fail: false
+
+      - name: Open an issue when links are broken
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
+        with:
+          title: Broken links found
+          content-filepath: lychee/out.md
+          labels: docs

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Check links
         id: lychee
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+        uses: lycheeverse/lychee-action@v2
         with:
           args: "--config lychee.toml --no-progress './**/*.md'"
           output: lychee/out.md
@@ -40,7 +40,7 @@ jobs:
 
       - name: Open an issue when links are broken
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
+        uses: peter-evans/create-issue-from-file@v5
         with:
           title: Broken links found
           content-filepath: lychee/out.md

--- a/.github/workflows/protect-agent-config.yml
+++ b/.github/workflows/protect-agent-config.yml
@@ -1,0 +1,149 @@
+name: Protect Agent Config
+
+# Two kinds of file are guarded here, for the same reason:
+#
+#   - `.github/**` — workflows and the scripts they run execute with this
+#     repository's credentials, so changing them is a supply-chain boundary
+#     rather than an ordinary code review.
+#   - `AGENTS.md`, `CLAUDE.md`, `.claude/**` — these are the standing
+#     instructions every coding agent working in this repo reads and follows.
+#     An edit here silently redirects future agent runs, including ones a
+#     maintainer kicks off against a later branch, which makes it a far more
+#     durable change than the diff's size suggests.
+#
+# A maintainer carries any legitimate change to these forward in their own PR.
+#
+# Deliberately no `paths:` filter on the trigger. A `pull_request_target`
+# filtered to these paths would not run at all on PRs that don't touch them,
+# and a required check that never runs stays *pending* forever, blocking every
+# merge. The job runs on every PR and exits 0 when nothing protected changed.
+
+on:
+  # pull_request_target is required so the guard runs from the base repository's
+  # default branch (a fork cannot disable it by editing this file) and can comment
+  # on fork PRs. Nothing here checks out or executes PR code: it only reads PR
+  # metadata via the API.
+  pull_request_target:
+    # `edited` is included because it is the only event fired when a PR's BASE
+    # branch changes, and the verdict is a diff against that base: without it a
+    # green check survives a base switch that changes which files the PR touches.
+    types: [opened, synchronize, reopened, edited]
+
+permissions: {}
+
+concurrency:
+  group: protect-agent-config-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Agent Config Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # `pull-requests: write` covers listing and posting the PR comment. No
+    # `contents:` scope: this job never checks out the repository.
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Block external changes to agent config
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_STATE: ${{ github.event.pull_request.state }}
+        run: |
+          set -euo pipefail
+
+          echo "PR #${PR_NUMBER} by ${PR_AUTHOR}"
+
+          # `edited` also fires on closed and merged PRs (a bot rewriting the
+          # description, an author tidying the title), where there is no merge to guard.
+          if [ "$PR_STATE" != "open" ]; then
+            echo "PR is ${PR_STATE}; nothing to guard."
+            exit 0
+          fi
+
+          # Changed files first: most PRs touch nothing protected and stop here, so the
+          # permission lookup below only runs when it matters. One JSON object per file.
+          TOTAL_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.changed_files')
+          PR_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files?per_page=100" --paginate \
+            --jq '.[] | {filename, previous_filename} | tojson')
+          RETRIEVED_FILES=$(printf '%s' "$PR_FILES" | grep -c '^{') || true
+
+          # That endpoint hard-caps at 3000 files and truncates rather than erroring, so a
+          # PR padded past the cap could push a protected edit out of the response and be
+          # waved through. Fail closed on a short list rather than deciding on a partial
+          # changeset.
+          if [ "$RETRIEVED_FILES" -lt "$TOTAL_FILES" ]; then
+            echo "::error::Retrieved only ${RETRIEVED_FILES} of ${TOTAL_FILES} changed files (the PR files API caps at 3000)." \
+              "Cannot verify the protected paths are untouched, so failing closed rather than passing blind."
+            exit 1
+          fi
+
+          # `previous_filename` catches a rename *out of* a protected path, which changes
+          # the effective config just as much as an edit in place.
+          PROTECTED_FILES=$(printf '%s\n' "$PR_FILES" \
+            | jq -r '.filename, (.previous_filename // empty)' \
+            | grep -E '^(\.github/|\.claude/|AGENTS\.md$|CLAUDE\.md$)' | sort -u) || true
+
+          if [ -z "$PROTECTED_FILES" ]; then
+            echo "No protected files changed."
+            exit 0
+          fi
+
+          echo "Protected files changed:"
+          printf '%s\n' "$PROTECTED_FILES"
+
+          # Dependabot bumps the action pins in `.github/workflows/` — it is configured for
+          # the `github-actions` ecosystem in `.github/dependabot.yml`, so blocking it would
+          # freeze those updates. It is the *only* allowlisted bot; a blanket `*[bot]` glob
+          # would hand the bypass to any bot installed later.
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "Author is dependabot; allowed."
+            exit 0
+          fi
+
+          # The author's resolved permission on THIS repository is the only trust signal:
+          #   - a base-repo head branch does NOT imply push access, since GitHub Apps push
+          #     branches straight into this repo.
+          #   - `author_association` reports CONTRIBUTOR for maintainers with private org
+          #     membership, so it wrongly blocks people it should wave through.
+          # `.permission`, not `.role_name`: the latter can be an arbitrary custom role name
+          # that fails a hardcoded match, while `.permission` maps maintain and custom roles
+          # onto their stable base access level. Fails closed — this is a security boundary.
+          AUTHOR_PERMISSION=$(gh api "repos/${REPO}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>/dev/null || echo "unknown")
+          case "$AUTHOR_PERMISSION" in
+            write | admin)
+              echo "Author ${PR_AUTHOR} has ${AUTHOR_PERMISSION} access to this repo; allowed."
+              exit 0
+              ;;
+            *)
+              echo "Author ${PR_AUTHOR} repo permission: ${AUTHOR_PERMISSION}; not permitted to change agent config."
+              ;;
+          esac
+
+          # One comment per PR. `synchronize` re-runs this on every push, and repeating the
+          # explanation each time would bury the rest of the review; the failing check is the
+          # signal that the branch is still blocked. Matching on the marker alone would let
+          # anyone suppress the explanation for good by pasting it into a comment, so the
+          # poster has to be us too.
+          MARKER="<!-- protect-agent-config-guard -->"
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --paginate \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${MARKER}\"))) | .id")
+
+          if [ -z "$EXISTING" ]; then
+            PROTECTED_LIST=$(printf '%s\n' "$PROTECTED_FILES" | awk '{ print "- `" $0 "`" }')
+            COMMENT=$(printf '%s\n\n%s\n\n%s\n\n%s\n%s\n\n%s\n' \
+              "Thanks for the PR! One thing blocks it: it changes CI or coding-agent configuration, which we can only accept from maintainers." \
+              "**What to do:** drop those changes from this branch (\`git checkout origin/main -- .github .claude AGENTS.md CLAUDE.md\` and push) — the rest of your work is unaffected and still very welcome. If the change is needed for the rest to work, say so in a comment and a maintainer will carry it forward in a separate PR." \
+              "**Why:** files under \`.github/\` run with this repository's credentials, and \`AGENTS.md\` / \`CLAUDE.md\` / \`.claude/\` are the standing instructions every coding agent in this repo follows. Both are supply-chain boundaries. This is an automatic rule, not a judgement on your change." \
+              "Protected files changed by this PR:" \
+              "$PROTECTED_LIST" \
+              "$MARKER")
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT"
+          else
+            echo "Explanatory comment already posted; not repeating it."
+          fi
+
+          exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
         args:
@@ -24,22 +24,21 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args:
-          - "--py312-plus"
+          - "--py310-plus"
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v2.3.1
     hooks:
       - id: mypy
         additional_dependencies:
           - types-requests
           - types-PyYAML
-        args: [--ignore-missing-imports, --no-strict-optional]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at douglas.trajano@outlook.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest released version of `pydantic-ai-skills` receives security fixes.
+Fixes are released as a new patch version; there are no long-term support branches.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Report them privately through
+[GitHub Security Advisories](https://github.com/dougtrajano/pydantic-ai-skills/security/advisories/new),
+which lets us discuss and fix the issue before it is disclosed.
+
+Please include as much of the following as you can:
+
+- The type of issue (for example: path traversal, arbitrary script execution, credential exposure)
+- The affected version, and the source file and function if you have identified them
+- Step-by-step instructions to reproduce it, ideally with a minimal proof of concept
+- The impact you believe it has
+
+You can expect an initial response within 7 days. If the report is accepted, we will keep
+you updated on the fix and credit you in the advisory unless you prefer otherwise.
+
+## Scope
+
+This package discovers skills from the filesystem and remote registries, exposes bundled
+resources to a model, and can execute skill scripts as subprocesses. The trust boundaries
+that follow from that — and what this package does and does not defend against — are
+documented in the [security model](https://dougtrajano.github.io/pydantic-ai-skills/security/).
+
+Read it before reporting: **skills are executable code, and loading an untrusted skill is
+equivalent to running untrusted code.** That is a documented property of the design, not a
+vulnerability. Reports that are in scope include path-traversal or symlink escapes from the
+skills directory, bypasses of the sandbox script executors, and credential exposure through
+registry handling.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -165,19 +165,17 @@ def test_get_skill_not_found():
 - Add/update docstrings
 - Update relevant docs/ pages
 
-### 2. Update CHANGELOG
+### 2. Label the PR for the release notes
 
-Add an entry under "Unreleased":
+There is no `CHANGELOG.md`. Release notes are generated from merged PR titles, grouped by
+label, as configured in [`.github/release.yml`](https://github.com/dougtrajano/pydantic-ai-skills/blob/main/.github/release.yml).
 
-```markdown
-## [Unreleased]
+So two things matter:
 
-### Added
-- New feature description (#PR_NUMBER)
-
-### Fixed
-- Bug fix description (#PR_NUMBER)
-```
+- **The PR title is the changelog entry.** Write it for someone reading the
+  [releases page](https://github.com/dougtrajano/pydantic-ai-skills/releases), not for the diff.
+- **Apply one label**: `feature`, `bug`, or `dependency` to place it in a section;
+  `docs` or `chore` to leave it out of the notes entirely.
 
 ### 3. Create Pull Request
 
@@ -188,42 +186,27 @@ Add an entry under "Unreleased":
 
 ### PR Template
 
-```markdown
-## Description
-Brief description of changes
+GitHub fills this in for you from
+[`.github/pull_request_template.md`](https://github.com/dougtrajano/pydantic-ai-skills/blob/main/.github/pull_request_template.md)
+when you open the PR. Work through the checklist it gives you rather than copying one from here.
 
-## Type of Change
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation update
-
-## Checklist
-- [ ] Tests added/updated
-- [ ] Documentation updated
-- [ ] CHANGELOG updated
-- [ ] All tests pass
-- [ ] Pre-commit checks pass
-```
+One item on it is worth calling out: if you used an AI coding agent, you are attesting that
+you reviewed its output line by line and stand behind it. Generated code is welcome; unread
+generated code is not.
 
 ## Reporting Issues
 
-### Bug Reports
+Open an issue from the [issue templates](https://github.com/dougtrajano/pydantic-ai-skills/issues/new/choose).
+The bug and feature-request forms prompt for everything needed to act on the report —
+versions, a minimal reproducible example, expected versus actual behavior for bugs; use case,
+proposal, and alternatives considered for features.
 
-Include:
-- Python version
-- pydantic-ai-skills version
-- Minimal reproducible example
-- Expected vs actual behavior
-- Full error traceback
+Usage questions belong in
+[Discussions](https://github.com/dougtrajano/pydantic-ai-skills/discussions) instead.
 
-### Feature Requests
-
-Include:
-- Use case description
-- Proposed solution
-- Alternative approaches considered
-- Examples of usage
+Security vulnerabilities are the exception: **do not open a public issue**. Report them
+privately as described in
+[`SECURITY.md`](https://github.com/dougtrajano/pydantic-ai-skills/blob/main/SECURITY.md).
 
 ## Community Guidelines
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,25 @@
+# Configuration for the weekly link check (.github/workflows/link-check.yml).
+
+# Some hosts answer automated requests with 403/429 while serving the page fine
+# in a browser. Treating those as broken would train us to ignore the report.
+accept = ["200..=299", "403", "429"]
+user_agent = "Mozilla/5.0 (compatible; lychee link checker; +https://github.com/dougtrajano/pydantic-ai-skills)"
+scheme = ["https", "http"]
+
+max_concurrency = 8
+max_retries = 2
+timeout = 20
+
+exclude_path = [
+  ".venv",
+  "site",
+  "htmlcov",
+  "examples/anthropic-skills",
+]
+
+exclude = [
+  # Placeholder URLs used in documentation examples.
+  "^https?://(localhost|127\\.0\\.0\\.1|example\\.com)",
+  # Login-gated, always 401/403 for an anonymous checker.
+  "^https?://(www\\.)?linkedin\\.com",
+]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,9 +100,6 @@ validation:
   unrecognized_links: warn
   anchors: warn
 
-extra_css:
-  - "extra/tweaks.css"
-
 markdown_extensions:
   - abbr
   - admonition
@@ -132,9 +129,6 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
-      options:
-        custom_icons:
-          - docs/.overrides/.icons
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Operating System :: OS Independent",
@@ -30,7 +31,10 @@ requires-python = ">=3.10"
 dependencies = [
     "anyio>=4.0.0",
     "pydantic-ai-slim>=1.105",
-    "pyyaml>=6.0",
+    # 6.0.1 is the floor, not 6.0: pyyaml 6.0 ships no wheels for Python 3.12+
+    # and its sdist fails to build against Cython 3 ("build_ext has no attribute
+    # cython_sources"). Caught by the test-lowest-versions CI job.
+    "pyyaml>=6.0.1",
 ]
 
 [project.urls]
@@ -65,7 +69,10 @@ localsandbox = [
 ]
 test = [
     "pytest>=8.0.0",
-    "pytest-asyncio>=0.23.0",
+    # 0.23.5 is the floor, not 0.23.0: earlier 0.23.x crashes at collection
+    # against pytest 8 ("'Package' object has no attribute 'obj'").
+    # Caught by the test-lowest-versions CI job.
+    "pytest-asyncio>=0.23.5",
     "pytest-cov>=4.1.0",
     "types-PyYAML>=6.0.12",
 ]
@@ -92,7 +99,7 @@ examples = [
 [tool.ruff]
 line-length = 120
 target-version = "py310"
-include = ["pydantic_ai_skills/**/*.py", "examples/**/*.py"]
+include = ["pydantic_ai_skills/**/*.py", "examples/**/*.py", "tests/**/*.py"]
 
 [tool.ruff.lint]
 extend-select = [
@@ -142,3 +149,9 @@ packages = ["pydantic_ai_skills"]
 # which Sonar resolves from the repo root and fails to match -> 0% coverage.
 relative_files = true
 source = ["pydantic_ai_skills"]
+
+[tool.mypy]
+# Kept here rather than in .pre-commit-config.yaml args so a bare `mypy` run
+# behaves the same as the pre-commit hook and CI.
+ignore_missing_imports = true
+strict_optional = false

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,6 @@ sonar.projectKey=DougTrajano_pydantic-ai-skills
 sonar.organization=dougtrajano
 sonar.sources=pydantic_ai_skills
 sonar.tests=tests
-sonar.python.version=3.10,3.11,3.12,3.13
+sonar.python.version=3.10,3.11,3.12,3.13,3.14
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.cpd.exclusions=**/pydantic_ai_skills/types.py

--- a/tests/test_repo_consistency.py
+++ b/tests/test_repo_consistency.py
@@ -1,0 +1,137 @@
+"""Guard against drift between the files that declare which Pythons we support.
+
+The supported-Python set is spelled out in five places that nothing links
+together: the CI matrix, the package classifiers, ``requires-python``, the
+SonarCloud properties, and the pyupgrade target. A change that updates one and
+misses the others is silent -- CI stays green while the package advertises the
+wrong versions, or pyupgrade emits syntax the floor interpreter cannot parse.
+These tests make that a test failure instead.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 has no tomllib
+    tomllib = None  # type: ignore[assignment]
+
+pytestmark = pytest.mark.skipif(
+    tomllib is None,
+    reason='tomllib is only available on Python 3.11+; these checks run on the rest of the matrix',
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PYPROJECT = REPO_ROOT / 'pyproject.toml'
+CI_WORKFLOW = REPO_ROOT / '.github' / 'workflows' / 'ci.yml'
+SONAR_PROPERTIES = REPO_ROOT / 'sonar-project.properties'
+PRE_COMMIT_CONFIG = REPO_ROOT / '.pre-commit-config.yaml'
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Turn a dotted version string into a sortable tuple of ints."""
+    return tuple(int(part) for part in version.split('.'))
+
+
+def _sorted_versions(versions: set[str]) -> list[str]:
+    """Sort dotted version strings numerically rather than lexicographically."""
+    return sorted(versions, key=_version_tuple)
+
+
+@pytest.fixture(scope='module')
+def pyproject() -> dict:
+    """Parse pyproject.toml once for the whole module."""
+    return tomllib.loads(PYPROJECT.read_text(encoding='utf-8'))
+
+
+@pytest.fixture(scope='module')
+def ci_matrix_versions() -> set[str]:
+    """Python versions exercised by the ``test`` job matrix in CI."""
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding='utf-8'))
+    versions = workflow['jobs']['test']['strategy']['matrix']['python-version']
+    # The matrix quotes them ("3.10") so YAML keeps 3.10 distinct from 3.1.
+    assert all(isinstance(version, str) for version in versions), (
+        'Quote every python-version in the CI matrix, otherwise YAML parses 3.10 as the float 3.1.'
+    )
+    return set(versions)
+
+
+@pytest.fixture(scope='module')
+def classifier_versions(pyproject: dict) -> set[str]:
+    """Python versions advertised by the ``Programming Language`` classifiers."""
+    pattern = re.compile(r'^Programming Language :: Python :: (\d+\.\d+)$')
+    matches = (pattern.match(classifier) for classifier in pyproject['project']['classifiers'])
+    return {match.group(1) for match in matches if match}
+
+
+@pytest.fixture(scope='module')
+def sonar_versions() -> set[str]:
+    """Python versions declared in sonar-project.properties."""
+    text = SONAR_PROPERTIES.read_text(encoding='utf-8')
+    match = re.search(r'^sonar\.python\.version=(.+)$', text, re.MULTILINE)
+    assert match is not None, 'sonar-project.properties is missing sonar.python.version'
+    return {version.strip() for version in match.group(1).split(',')}
+
+
+def test_classifiers_match_ci_matrix(classifier_versions: set[str], ci_matrix_versions: set[str]) -> None:
+    """Every Python CI tests is advertised in the classifiers, and vice versa."""
+    assert _sorted_versions(classifier_versions) == _sorted_versions(ci_matrix_versions), (
+        'pyproject.toml classifiers and the ci.yml test matrix disagree. '
+        f'classifiers={_sorted_versions(classifier_versions)} matrix={_sorted_versions(ci_matrix_versions)}'
+    )
+
+
+def test_sonar_versions_match_ci_matrix(sonar_versions: set[str], ci_matrix_versions: set[str]) -> None:
+    """SonarCloud analyses the same Python versions CI tests."""
+    assert _sorted_versions(sonar_versions) == _sorted_versions(ci_matrix_versions), (
+        'sonar-project.properties and the ci.yml test matrix disagree. '
+        f'sonar={_sorted_versions(sonar_versions)} matrix={_sorted_versions(ci_matrix_versions)}'
+    )
+
+
+def test_requires_python_floor_matches_ci_matrix(pyproject: dict, ci_matrix_versions: set[str]) -> None:
+    """``requires-python`` declares exactly the lowest version CI tests."""
+    requires_python = pyproject['project']['requires-python']
+    match = re.fullmatch(r'>=\s*(\d+\.\d+)', requires_python.strip())
+    assert match is not None, f'Expected requires-python of the form ">=X.Y", got {requires_python!r}'
+
+    lowest_tested = _sorted_versions(ci_matrix_versions)[0]
+    assert match.group(1) == lowest_tested, (
+        f'requires-python floor is {match.group(1)} but the lowest Python in the CI matrix is {lowest_tested}.'
+    )
+
+
+def test_ruff_target_version_matches_floor(pyproject: dict, ci_matrix_versions: set[str]) -> None:
+    """Ruff targets the floor, so it flags syntax the oldest interpreter rejects."""
+    target = pyproject['tool']['ruff']['target-version']
+    expected = 'py' + _sorted_versions(ci_matrix_versions)[0].replace('.', '')
+    assert target == expected, f'[tool.ruff] target-version is {target!r}, expected {expected!r} to match the floor.'
+
+
+def test_pyupgrade_does_not_exceed_floor(ci_matrix_versions: set[str]) -> None:
+    """Reject a pyupgrade target that could emit syntax the floor interpreter cannot parse."""
+    config = yaml.safe_load(PRE_COMMIT_CONFIG.read_text(encoding='utf-8'))
+    args = [
+        arg
+        for repo in config['repos']
+        for hook in repo['hooks']
+        if hook['id'] == 'pyupgrade'
+        for arg in hook.get('args', [])
+    ]
+    assert args, 'Could not find the pyupgrade hook args in .pre-commit-config.yaml'
+
+    targets = [re.fullmatch(r'--py(\d)(\d+)-plus', arg) for arg in args]
+    matched = [match for match in targets if match]
+    assert matched, f'pyupgrade has no --pyXY-plus argument, got {args}'
+
+    floor = _version_tuple(_sorted_versions(ci_matrix_versions)[0])
+    for match in matched:
+        target = (int(match.group(1)), int(match.group(2)))
+        assert target <= floor, (
+            f'pyupgrade targets {match.group(0)} but the lowest supported Python is '
+            f'{".".join(str(part) for part in floor)}; it can emit syntax that version cannot parse.'
+        )


### PR DESCRIPTION
<!-- Thanks for contributing to pydantic-ai-skills! -->

Adopts the parts of [`pydantic/pydantic-ai`](https://github.com/pydantic/pydantic-ai)'s `.github` that pay off at this repo's size, and fixes the drift found while comparing against it. Deliberately skipped as too heavy: gh-aw agentic workflows, the LLM PR reviewer, `pr-guard.yml`, smokeshow, zizmor, and spend telemetry.

## Summary

### Two real bugs, both found by a new CI job

`test-lowest-versions` resolves every direct dependency to its declared floor. It immediately found two floors that were **wrong, not merely untested**:

- **`pyyaml>=6.0` → `>=6.0.1`.** 6.0 ships no wheels for Python 3.12+ and its sdist fails to build against Cython 3 (`'build_ext' object has no attribute 'cython_sources'`). Anyone on 3.12 resolving to the floor gets a build failure.
- **`pytest-asyncio>=0.23.0` → `>=0.23.5`.** Earlier 0.23.x crashes at collection against pytest 8 (`'Package' object has no attribute 'obj'`). 0.23.5 is the bisected minimum.

Both verified afterwards on Python 3.10 and 3.12 with every dependency pinned to its floor.

### CI hardening — `.github/workflows/ci.yml`

- **`check` aggregate job** (`re-actors/alls-green`) as the single required status check, replacing 15 matrix job names in branch protection.
- **Concurrency fix.** The old group cancelled the run for the previous commit to `main`; now only PRs cancel their superseded runs.
- **`permissions: contents: read`** at the workflow level.
- **`build` job** — `uv build` + `twine check --strict`, so packaging breakage surfaces on the PR that causes it instead of at release time.
- **`docs` job** — `mkdocs build --strict`. Docs previously built only on push to `main`, so breakage was invisible on PRs.
- Actions referenced by version tag (not SHA), kept current by Dependabot's `github-actions` ecosystem.

### Config drift — now enforced by `tests/test_repo_consistency.py`

A small linter for our own CI config (scaled-down `agentic_workflow_guard.py`), asserting the supported-Python set agrees across the CI matrix, classifiers, `requires-python`, `sonar-project.properties`, and the pyupgrade target. Drift it caught:

- **Python 3.14** was in the CI matrix but missing from the classifiers and Sonar.
- **pyupgrade `--py312-plus` → `--py310-plus`.** It could emit 3.12-only syntax into a package whose floor is 3.10 — a live bug.
- Pre-commit hook revs bumped so local, hook, and CI agree; mypy settings moved from hook args into `[tool.mypy]`; `tests/` now linted.

### Agent guardrails

- **PR template** with a checklist item attesting that any AI generated code was reviewed line-by-line by its human author.
- **`protect-agent-config.yml`** blocks PRs from non-maintainers touching `.github/`, `AGENTS.md`, `CLAUDE.md`, or `.claude/`. These change how CI and every *future* agent run behave, so they're a supply-chain boundary rather than an ordinary review. Fails closed; never checks out PR code.
- **`upstream-watch` slash command.** The log in `.github/upstream-watch.md` had no in-repo definition of the routine that produces it — it lived only in chat history.

### Repo hygiene

- Issue forms, `SECURITY.md`, `CODE_OF_CONDUCT.md` (the docs linked to a code of conduct that didn't exist).
- `.github/release.yml` — release notes generated from labelled PR titles, replacing docs that told contributors to update a `CHANGELOG.md` that didn't exist.
- Weekly lychee link check, which is exactly what catches dead links like the one above.
- Removed two `mkdocs.yml` references to files that have never existed; they'd have failed the new strict docs build.

## Reviewer notes

Two deliberate deviations from the plan:

- **Ruff pinned to v0.15.22, not v0.16.3.** `autoupdate` pulled 0.16.3, which flagged 24 findings (`SIM117`, `BLE001`, `DTZ005`, `S102`, `TRY004`…) that are **not** in our `extend-select` — 0.16 expanded its *default* rule set. That's a repo-wide change in what's enforced, and some findings need real judgment. v0.15.22 matches the `dev` extra and the local venv exactly. **Adopting 0.16 deserves its own PR.**
- **No `question.yaml` issue form.** `config.yml` routes questions to Discussions, which `docs/contributing.md` already pointed at.

Because `protect-agent-config.yml` uses `pull_request_target`, its *blocking* path can only be exercised from a fork — on this PR it runs and passes, since the author resolves to `admin`. The protected-path regex was tested against the tricky cases (`docs/AGENTS.md` and `.githubfoo/` correctly don't match).

**Two manual steps before this is fully live:**

1. Switch branch protection to require only `Check` (plus `Agent Config Guard` and the SonarCloud status). Until then the 15 old matrix names are still required and the aggregate job buys nothing.
2. Create the labels `feature`, `bug`, `dependency`, `docs`, `chore` — `.github/release.yml` and the PR template both assume they exist.

## Verification

- `pre-commit run --all-files` — passes, including the new `tests/` lint scope and mypy 2.3.1.
- `pytest` — 551 passed, 95% coverage.
- Lowest-direct floors on Python 3.12 (551 passed) and 3.10 (546 passed, 5 skipped — the `tomllib`-gated consistency tests, as designed).
- `uv build` + `twine check --strict` — both artifacts PASSED.
- `mkdocs build --strict` — exit 0.
- Drift test negative path confirmed: removing 3.13 from the classifiers fails it with a clear message.

## Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] **Tests** added or updated for any behavior change (`pytest`).
- [x] `pre-commit run --all-files` passes.
- [x] Docs updated if behavior, configuration, or public API changed.
- [x] New code works against the **floor** (`pydantic-ai-slim>=1.105`, Python 3.10), not just the latest.
- [x] **PR title** is fit for the [release changelog](https://github.com/dougtrajano/pydantic-ai-skills/releases), and the PR is labelled `feature`, `bug`, `dependency`, `docs`, or `chore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

