### PR TITLE
ci: report the SonarCloud quality gate on the PR head commit

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -6,6 +6,13 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  # Reading artifacts from the triggering CI run.
+  actions: read
+  # Posting the quality gate check run onto the PR head commit (final step).
+  checks: write
+
 jobs:
   sonarcloud:
     name: SonarCloud Scan
@@ -55,7 +62,11 @@ jobs:
           echo "pr_head_ref=${PR_HEAD_REF}" >> $GITHUB_OUTPUT
 
       - name: SonarCloud Scan (PR)
+        id: sonar_pr
         if: steps.pr_meta.outputs.pr_number != ''
+        # Must reach the reporting step below even when the gate fails, so the
+        # verdict lands on the PR instead of being lost as a red job against main.
+        continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -64,9 +75,69 @@ jobs:
             -Dsonar.pullrequest.key=${{ steps.pr_meta.outputs.pr_number }}
             -Dsonar.pullrequest.branch=${{ steps.pr_meta.outputs.pr_head_ref }}
             -Dsonar.pullrequest.base=${{ steps.pr_meta.outputs.pr_base_ref }}
+            -Dsonar.qualitygate.wait=true
 
       - name: SonarCloud Scan (push to main)
         if: steps.pr_meta.outputs.pr_number == ''
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      # This workflow is triggered by `workflow_run`, and GitHub attributes such runs
+      # to the default branch — so this job's own check run lands on main's HEAD, never
+      # on the PR being analysed. That makes it impossible to require in branch
+      # protection: a required check that never appears on the PR leaves it pending
+      # forever. The scan itself is fine (SonarCloud decorates the PR with a comment);
+      # only the *check* goes to the wrong commit.
+      #
+      # So report the gate explicitly against the PR head SHA, which the CI run
+      # captured in pr-metadata.env. `SonarCloud Quality Gate` is then a normal check
+      # on the PR and can be made a required status check.
+      - name: Report quality gate on the PR commit
+        # `always()` because the scan step above is expected to fail on a failing gate.
+        if: always() && steps.pr_meta.outputs.pr_number != '' && steps.pr_meta.outputs.pr_head_sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.pr_meta.outputs.pr_head_sha }}
+          PR_NUMBER: ${{ steps.pr_meta.outputs.pr_number }}
+          # 'success' | 'failure' — the outcome before continue-on-error masked it.
+          SCAN_OUTCOME: ${{ steps.sonar_pr.outcome }}
+        run: |
+          set -euo pipefail
+
+          PROJECT_KEY=$(grep -E '^sonar\.projectKey=' sonar-project.properties | cut -d= -f2-)
+          DETAILS_URL="https://sonarcloud.io/summary/new_code?id=${PROJECT_KEY}&pullRequest=${PR_NUMBER}"
+
+          # `-Dsonar.qualitygate.wait=true` makes the scanner block until the gate is
+          # computed and exit non-zero when it fails, so the step outcome IS the verdict.
+          if [ "$SCAN_OUTCOME" = "success" ]; then
+            CONCLUSION=success
+            TITLE="Quality Gate passed"
+          else
+            CONCLUSION=failure
+            TITLE="Quality Gate failed"
+          fi
+
+          SUMMARY="SonarCloud analysis for PR #${PR_NUMBER}. [View the full report](${DETAILS_URL})."
+
+          # Built with jq so the payload survives quoting and any special characters.
+          jq -n \
+            --arg name 'SonarCloud Quality Gate' \
+            --arg head_sha "$HEAD_SHA" \
+            --arg conclusion "$CONCLUSION" \
+            --arg details_url "$DETAILS_URL" \
+            --arg title "$TITLE" \
+            --arg summary "$SUMMARY" \
+            '{
+              name: $name,
+              head_sha: $head_sha,
+              status: "completed",
+              conclusion: $conclusion,
+              details_url: $details_url,
+              output: {title: $title, summary: $summary}
+            }' \
+          | gh api "repos/${REPO}/check-runs" --input - --jq '"posted \(.name)=\(.conclusion) on \(.head_sha[0:7])"'
+
+          # Mirror the gate onto this job, so a failing gate is also visible here.
+          [ "$CONCLUSION" = "success" ]


### PR DESCRIPTION
- Closes #<issue>

## Summary

SonarCloud already analyses every PR — the decorated comment proves it — but its **check run never lands on the PR**. `sonarqube.yml` is triggered by `workflow_run`, and GitHub attributes those runs to the default branch, so the check attaches to `main`'s HEAD instead.

Measured across the last five PRs:

| Commit | Sonar check runs |
|---|---|
| PR #73, #72, #71, #70, #69 head commits | **0** |
| `main` merge commits for #72, #71, #70, #69 | `SonarCloud Code Analysis` |

That made a Sonar gate impossible to require: a required check that never appears on the PR leaves it pending forever.

This posts the gate explicitly against the PR head SHA — already captured in `pr-metadata.env` by the CI run — so **`SonarCloud Quality Gate`** becomes an ordinary PR check that can be marked required.

## Changes

- `-Dsonar.qualitygate.wait=true` on the PR scan, so the scanner blocks until the gate is computed and exits non-zero when it fails. The step outcome *is* the verdict — no second API round-trip needed.
- That step is `continue-on-error: true`, so a failing gate still reaches the reporting step instead of dying as a red job against `main`.
- New reporting step builds the check-run payload with `jq` (quoting-safe) and POSTs it to `repos/{repo}/check-runs`, then mirrors the verdict onto the job itself.
- Explicit `permissions` block — `checks: write` for the new check run, `actions: read` for the cross-run artifact downloads, `contents: read`. The workflow previously inherited the repo default.

## Why not just switch the trigger to `pull_request`

That was the obvious fix and it's the wrong one here. Fork PRs cannot read `secrets.SONAR_TOKEN` under `pull_request`, so the scan would silently stop analysing exactly the contributions that most need it. This repo has had **three fork PRs** (#46, #11, #10). The `workflow_run` trigger exists precisely to give them a token, so it's preserved.

## Reviewer notes

This PR is its own test: if the mechanism works, a `SonarCloud Quality Gate` check appears on this PR's head commit — something that has never happened before on any PR in this repo.

The payload construction was validated locally for both the pass and fail branches. What can't be validated until this runs: whether `GITHUB_TOKEN` with `checks: write` is accepted by the check-runs endpoint from a `workflow_run` context.

**After merge**, add `SonarCloud Quality Gate` to branch protection alongside `Check` and `Agent Config Guard` — but only once you've seen it appear on a PR.

## Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] **Tests** added or updated for any behavior change (`pytest`) — n/a, CI config only.
- [x] `pre-commit run --all-files` passes.
- [x] Docs updated if behavior, configuration, or public API changed — n/a.
- [x] New code works against the **floor** — n/a.
- [x] **PR title** is fit for the release changelog, and the PR is labelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
