### PR TITLE
chore: upstream watch 2026-08-21 (no changes needed)

### DIFF
--- a/.github/upstream-watch.md
+++ b/.github/upstream-watch.md
@@ -4,6 +4,48 @@ Tracks the last `pydantic-ai` / `pydantic-ai-harness` releases reviewed by the w
 upstream-watch routine. Newest entry first. The top entry's tags are the lower bound
 for the next run.
 
+## 2026-08-21
+
+- **pydantic/pydantic-ai**: checked through `v2.33.0` (published 2026-08-20). Reviewed
+  `v2.32.0`–`v2.33.0`.
+- **pydantic/pydantic-ai-harness**: checked through `v0.24.0` (published 2026-08-19).
+  Reviewed `v0.23.0`–`v0.24.0`.
+- **Verdict**: No action needed. `v2.32.0`–`v2.33.0` migrate pydantic-ai's own HTTP layer
+  (including the Anthropic provider) from `httpx` to `httpx2` (#7351, #7657) — this package
+  declares `httpx>=0.28.0` only under the `examples` extra and never imports it, so the
+  migration doesn't reach it. The remaining feature/bugfix items (model-name suggestions,
+  xAI/OpenRouter provider changes, instrumentation v6, `RunContext.cancel()` fixes,
+  `FunctionModel` callable handling, Bedrock/DeepSeek/Temporal provider fixes) touch model
+  providers, span instrumentation, and `pydantic_evals`/Temporal integrations this package
+  doesn't use. Confirmed by diffing `v2.31.1...v2.33.0` in a local clone
+  (`git diff --stat` against `_function_schema.py`, `_griffe.py`, `_utils.py`,
+  `capabilities/capability.py`, `toolsets/abstract.py`, `toolsets/function.py`): only
+  `_utils.py`, `capabilities/hooks.py`, and `toolsets/function.py` changed, all from a single
+  PR (#7557, "Run sync hooks in thread pool and enforce timeout for blocking sync tools").
+  That PR adds an `abandon_threads_on_cancel()` context manager and wires it into
+  `run_in_executor()` and `FunctionToolset`'s per-tool timeout handling; `run_in_executor()`
+  and `is_async_callable()` keep the exact signatures this package calls in
+  `pydantic_ai_skills/local.py`, the new behavior only activates inside that context manager
+  (which `SkillsToolset`/`local.py` never enter), and `SkillsToolset` (a `FunctionToolset`
+  subclass) doesn't override the touched timeout-handling method — so the change is fully
+  transparent here. `#7571` (tool-result message ordering for Bedrock) and `#7572` (unknown-tool
+  retry message filtering) were checked directly against their file lists and confirmed to
+  touch only `_agent_graph.py`/`messages.py`/`tool_manager.py` internals, not
+  `AbstractCapability`, `AbstractToolset`, `RunContext`, or `defer_loading` semantics.
+  `pydantic-ai-harness` `v0.23.0` (`ManagedPrompt` baggage/`FallbackCompaction`) and `v0.24.0`
+  (serializer presets, `FileSystem` path/failure handling, `PlaywrightBrowser` and
+  `YouSearch`/`YouResearch` capabilities) are entirely harness-internal — this package has no
+  dependency on `pydantic-ai-harness`, so these are tracked but out of scope as usual.
+  Verified empirically: `pytest` passes identically against both `pydantic-ai-slim==2.33.0`
+  (latest) and `pydantic-ai-slim==1.105.0` (the declared floor) — 550 passed, 1 pre-existing
+  failure (`test_discover_skills_os_error_handling`, a `chmod(0o000)` permission simulation
+  that has no effect when tests run as root in this environment; unrelated to pydantic-ai and
+  identical on both versions). `pre-commit run --all-files` (ruff, ruff-format, mypy) is clean.
+  The private symbols this package imports
+  (`pydantic_ai._function_schema.FunctionSchema`/`function_schema`,
+  `pydantic_ai._griffe.doc_descriptions`, `pydantic_ai._utils.is_async_callable`/
+  `run_in_executor`) are unchanged in signature and behavior for this package's usage.
+
 ## 2026-08-18
 
 - **pydantic/pydantic-ai**: checked through `v2.31.1` (published 2026-08-18). Reviewed


### PR DESCRIPTION
## Summary

Weekly upstream-watch review. No code changes — reviewed pydantic-ai and pydantic-ai-harness releases published since the last watch entry (2026-08-18) and found nothing that affects this package's private-symbol imports or public `AbstractToolset`/`AbstractCapability` surface.

### Releases reviewed

**pydantic/pydantic-ai** — [`v2.32.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.32.0) through [`v2.33.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.33.0):

- [`v2.32.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.32.0) (2026-08-18) — model-name suggestions, xAI/OpenRouter provider features, instrumentation v6, plus bug fixes including #7557 ("Run sync hooks in thread pool and enforce timeout for blocking sync tools") and the start of the `httpx` → `httpx2` migration (#7351).
- [`v2.32.1`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.32.1) (2026-08-19) — `Agent.run_sync()` guard fix, Anthropic thinking-block fix, `FunctionModel` callable handling.
- [`v2.32.2`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.32.2) (2026-08-20) — `pydantic_evals`, realtime `RunContext.cancel()`, `VideoUrl`, DeepSeek replay, and Temporal fixes.
- [`v2.33.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.33.0) (2026-08-20) — completes the `httpx2` migration for the Anthropic provider (#7657), required by `anthropic>=1.0.0`.

**Conclusion**: no action. This package declares `httpx>=0.28.0` only under the `examples` extra and never imports it, so the `httpx2` migration doesn't reach it. The other feature/bugfix items touch model providers, span instrumentation, `pydantic_evals`, and Temporal integrations this package doesn't use.

I diffed `v2.31.1...v2.33.0` in a local clone against the files this package actually depends on:

```
git diff --stat v2.31.1 v2.33.0 -- pydantic_ai_slim/pydantic_ai/_function_schema.py \
  pydantic_ai_slim/pydantic_ai/_griffe.py pydantic_ai_slim/pydantic_ai/_utils.py \
  pydantic_ai_slim/pydantic_ai/capabilities/capability.py \
  pydantic_ai_slim/pydantic_ai/toolsets/abstract.py \
  pydantic_ai_slim/pydantic_ai/toolsets/function.py
```

Only `_utils.py`, `capabilities/hooks.py`, and `toolsets/function.py` changed, all from a single PR, #7557. It adds an `abandon_threads_on_cancel()` context manager wired into `run_in_executor()` and `FunctionToolset`'s per-tool timeout handling. `run_in_executor()` and `is_async_callable()` keep the exact signatures `pydantic_ai_skills/local.py` calls; the new behavior only activates inside that context manager, which `SkillsToolset`/`local.py` never enter. `SkillsToolset` (a `FunctionToolset` subclass) doesn't override the touched timeout-handling method, so the change is fully transparent here.

I also checked #7571 (tool-result message ordering, for Bedrock) and #7572 (unknown-tool retry message filtering) directly against their file lists — both touch only `_agent_graph.py`/`messages.py`/`tool_manager.py` internals, not `AbstractCapability`, `AbstractToolset`, `RunContext`, or `defer_loading` semantics.

**pydantic/pydantic-ai-harness** — [`v0.23.0`](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.23.0) and [`v0.24.0`](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.24.0) (`ManagedPrompt`/`FallbackCompaction`, serializer presets, `FileSystem` hardening, `PlaywrightBrowser`/`YouSearch` capabilities) are entirely harness-internal. This package has no dependency on `pydantic-ai-harness` — tracked but out of scope, as in every prior entry.

### What changed

Only `.github/upstream-watch.md`, with a new dated entry recording the tags checked and this verdict.

## Verification

- `pip install -e ".[test,git,s3,dev]"` — succeeded.
- `pytest` against `pydantic-ai-slim==2.33.0` (latest): **550 passed, 1 pre-existing failure** (`test_discover_skills_os_error_handling` — a `chmod(0o000)` permission simulation that has no effect when tests run as root in this sandbox; unrelated to any pydantic-ai change).
- `pytest` against `pydantic-ai-slim==1.105.0` (the declared floor): identical result — same 550 passed, same single pre-existing root-related failure.
- `pre-commit run --all-files` (ruff, ruff-format, mypy): clean.

`tests/test_pydantic_ai_compat.py` (the private-import tripwire) passed against both versions, confirming `pydantic_ai._function_schema.{FunctionSchema,function_schema}`, `pydantic_ai._griffe.doc_descriptions`, and `pydantic_ai._utils.{is_async_callable,run_in_executor}` are all still importable with unchanged behavior for this package's usage.

## Checklist

- [x] Any AI generated code has been reviewed line-by-line — no source code changed, only the log entry.
- [x] Tests added or updated for any behavior change — n/a, no behavior change.
- [x] `pre-commit run --all-files` passes.
- [x] Docs updated if behavior, configuration, or public API changed — n/a.
- [x] New code works against the floor (`pydantic-ai-slim>=1.105`, Python 3.10) — verified empirically above (n/a, no new code).
- [x] PR title is fit for the release changelog, labelled `chore`.


---
_Generated by [Claude Code](https://claude.ai/code/session_018NVyoxpyyhUwveS1H9PH6E)_