### PR TITLE
chore: upstream watch 2026-08-28 (no changes needed)

### DIFF
--- a/.github/upstream-watch.md
+++ b/.github/upstream-watch.md
@@ -4,6 +4,53 @@ Tracks the last `pydantic-ai` / `pydantic-ai-harness` releases reviewed by the w
 upstream-watch routine. Newest entry first. The top entry's tags are the lower bound
 for the next run.
 
+## 2026-08-28
+
+- **pydantic/pydantic-ai**: checked through `v2.35.3` (published 2026-08-28). Reviewed
+  `v2.34.0`–`v2.35.3`.
+- **pydantic/pydantic-ai-harness**: checked through `v0.27.0` (published 2026-08-27).
+  Reviewed `v0.25.0`–`v0.27.0`.
+- **Verdict**: No action needed. Confirmed by diffing `v2.33.0...v2.35.3` in a local clone
+  (`git diff --stat` against `pydantic_ai/_function_schema.py`, `_griffe.py`, `_utils.py`,
+  `toolsets/abstract.py`, `toolsets/function.py`, `capabilities/`, `tools.py`): the three
+  private symbols this package imports (`pydantic_ai._function_schema.FunctionSchema`/
+  `function_schema`, `pydantic_ai._griffe.doc_descriptions`,
+  `pydantic_ai._utils.is_async_callable`/`run_in_executor`) have zero diff across the whole
+  window — untouched. `v2.35.0` (#7454, "deprecate `RunContext.capability_loaded`/
+  `available_capability_ids` in favor of `capability_active`/`active_capability_ids`") does
+  rename fields on `RunContext` and ripples through `CombinedCapability`'s internal
+  `_ctx_for_available_cap`→`_ctx_for_active_cap` plumbing, but `SkillsCapability` never reads
+  either old or new name (confirmed by grep: it only implements `get_toolset`,
+  `get_instructions`, and `get_description`, none of the `before_run`/`after_run`/
+  `prepare_tools`/etc. hooks `CombinedCapability` threads `capability_active` through), so the
+  rename is fully transparent here. `v2.35.0` (#7759, "tool descriptions explicitly set to
+  empty now remain empty rather than defaulting to the docstring") changed
+  `Tool.__init__`'s `description = description or self.function_schema.description` to
+  `description if description is not None else ...` in `tools.py` — the four tools this
+  package registers (`list_skills`, `load_skill`, `read_skill_resource`, `run_skill_script`)
+  are all added via the bare `@self.tool` decorator with no explicit `description=` argument,
+  so this only changes behavior for callers that pass `description=''`, which this package
+  never does. `v2.34.0`'s `#7679` ("Add a LangChain migration skill") only adds a `SKILL.md`
+  under pydantic-ai's own `.claude/`-style repo tooling for an internal migration guide — not
+  a change to any Agent Skills *support* in the library itself, and doesn't overlap with this
+  package's skill discovery. The remaining `v2.34.0`–`v2.35.3` items (GLM-5.3/Heroku model
+  support, `TestModel` JSON Schema edge cases, `VercelAIAdapter`/`VercelProvider`/`CohereModel`
+  fixes, Bedrock guardrail traces and structured-output routing, Temporal cancellation and
+  metric export changes, `dbos` extra dependency capping) touch model providers, evaluation
+  helpers, and Temporal/durable-execution integrations this package doesn't use. `#6937`
+  ("honor agent tool retry budget for `load_capability`") only affects the agent's own
+  built-in `load_capability` tool implementation, which `SkillsCapability` doesn't override.
+  `pydantic-ai-harness` `v0.25.0`–`v0.27.0` (compaction/spend-store internals, `Shell` spawn
+  failure handling, release-gate tooling, doc snippet checks) are entirely harness-internal —
+  this package has no dependency on `pydantic-ai-harness`, so these are tracked but out of
+  scope as usual; none mention Agent Skills, `SKILL.md`, or skill discovery. Verified
+  empirically: `pytest` passes identically against both `pydantic-ai-slim==2.35.3` (latest)
+  and `pydantic-ai-slim==1.105.0` (the declared floor) — 550 passed, 1 pre-existing failure
+  (`test_discover_skills_os_error_handling`, the same `chmod(0o000)`-as-root artifact noted in
+  prior entries, unrelated to pydantic-ai and identical on both versions). `pre-commit run
+  --all-files` (ruff, ruff-format, mypy) is clean. The private symbols this package imports
+  are unchanged in both signature and behavior for this package's usage.
+
 ## 2026-08-21
 
 - **pydantic/pydantic-ai**: checked through `v2.33.0` (published 2026-08-20). Reviewed


### PR DESCRIPTION
## Summary

Weekly upstream-watch review. No action needed — records the reviewed release ranges and verdict in `.github/upstream-watch.md`.

### Releases reviewed

- **pydantic/pydantic-ai**
  - [`v2.34.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.34.0) (2026-08-24) — LangChain-migration skill for pydantic-ai's own repo tooling (#7679), `load_capability` retry-budget fix (#6937), model-provider/`TestModel` bug fixes. No impact.
  - [`v2.35.0`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.35.0) (2026-08-26) — deprecates `RunContext.capability_loaded`/`available_capability_ids` in favor of `capability_active`/`active_capability_ids` (#7454); tool descriptions explicitly set to `''` no longer fall back to the docstring (#7759). No impact (see below).
  - [`v2.35.1`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.35.1) (2026-08-27) — Bedrock guardrail trace handling, Temporal cancellation, `dbos` dependency cap. No impact.
  - [`v2.35.3`](https://github.com/pydantic/pydantic-ai/releases/tag/v2.35.3) (2026-08-28) — Heroku GLM routing, cookie scoping, deferred-tool-request ID resolution, `dbos` dependency cap removed. No impact.
- **pydantic/pydantic-ai-harness**
  - [`v0.25.0`](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.25.0), [`v0.26.0`](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.26.0), [`v0.27.0`](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.27.0) — compaction/spend-store internals, `Shell` spawn-failure handling, release tooling, doc snippet checks. This package doesn't depend on `pydantic-ai-harness`; tracked but out of scope as always. No Agent Skills / `SKILL.md` overlap.

### What I concluded and why

Diffed `v2.33.0...v2.35.3` in a local clone of `pydantic/pydantic-ai` against exactly the files this package touches (`_function_schema.py`, `_griffe.py`, `_utils.py`, `toolsets/abstract.py`, `toolsets/function.py`, `capabilities/`, `tools.py`):

- `_function_schema.py`, `_griffe.py`, `_utils.py` — **zero diff** across the whole window. The private symbols this package imports (`FunctionSchema`/`function_schema`, `doc_descriptions`, `is_async_callable`/`run_in_executor`) are byte-for-byte unchanged.
- `#7454`'s `capability_loaded`→`capability_active` / `available_capability_ids`→`active_capability_ids` rename ripples through `CombinedCapability`'s internal `_ctx_for_available_cap`→`_ctx_for_active_cap` plumbing, but `SkillsCapability` only implements `get_toolset`, `get_instructions`, and `get_description` — none of the `before_run`/`after_run`/`prepare_tools`/etc. hooks that thread `capability_active` through — and never reads either the old or new `RunContext` field name. Confirmed by grep. Transparent.
- `#7759` changed `Tool.__init__` from `description = description or self.function_schema.description` to `description if description is not None else ...`. This package's four registered tools (`list_skills`, `load_skill`, `read_skill_resource`, `run_skill_script`) are all added via the bare `@self.tool` decorator with no explicit `description=` argument, so the changed branch is never taken here.
- `#6937` ("honor agent tool retry budget for `load_capability`") only affects the agent's own built-in `load_capability` tool, which `SkillsCapability` doesn't override.
- `#7679` ("Add a LangChain migration skill") adds a `SKILL.md` under pydantic-ai's own internal repo tooling for a migration guide — not a change to Agent Skills *support* in the library, and doesn't overlap with this package's skill discovery.
- The remaining items (GLM-5.3/Heroku model support, `TestModel` JSON Schema edge cases, `VercelAIAdapter`/`VercelProvider`/`CohereModel` fixes, Bedrock guardrail traces, Temporal cancellation/metric export, `dbos` dependency capping) touch model providers, evaluation helpers, and Temporal/durable-execution integrations this package doesn't use.

### What I changed

Only `.github/upstream-watch.md` — a new dated entry recording the tags checked and the verdict above, above the previous top entry (which recorded through `v2.33.0` / `v0.24.0`).

### Verification

- `pytest` against `pydantic-ai-slim==2.35.3` (latest): **550 passed**, 1 pre-existing failure (`test_discover_skills_os_error_handling` — a `chmod(0o000)` permission simulation that has no effect running as root in this environment; unrelated to pydantic-ai, noted in prior upstream-watch entries too).
- `pytest` against `pydantic-ai-slim==1.105.0` (the declared floor): identical result — **550 passed**, same 1 pre-existing failure.
- `pre-commit run --all-files` (ruff, ruff-format, mypy): clean.

## Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] **Tests** added or updated for any behavior change (`pytest`). *(No behavior change in this repo — nothing to add/update.)*
- [x] `pre-commit run --all-files` passes.
- [ ] Docs updated if behavior, configuration, or public API changed. *(N/A — no behavior/config/API change.)*
- [x] New code works against the **floor** (`pydantic-ai-slim>=1.105`, Python 3.10), not just the latest.
- [x] **PR title** is fit for the release changelog, and the PR should be labelled `chore`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUw5eedrxQtKxTWMgajgQn)_