### PR TITLE
fix: upstream watch 2026-09-04 (pydantic-ai WrapperToolset.get_instructions() shape change)

### DIFF
--- a/.github/upstream-watch.md
+++ b/.github/upstream-watch.md
@@ -4,6 +4,77 @@ Tracks the last `pydantic-ai` / `pydantic-ai-harness` releases reviewed by the w
 upstream-watch routine. Newest entry first. The top entry's tags are the lower bound
 for the next run.
 
+## 2026-09-04
+
+- **pydantic/pydantic-ai**: checked through `v2.39.0` (published 2026-09-04). Reviewed
+  `v2.36.0`–`v2.39.0`.
+- **pydantic/pydantic-ai-harness**: checked through `v0.29.0` (published 2026-09-03).
+  Reviewed `v0.28.0`–`v0.29.0`.
+- **Verdict**: One real, low-risk break found and fixed — this package's own test suite, not
+  its runtime code. `v2.38.0`'s `toolsets/function.py` and `toolsets/wrapper.py` changes
+  (part of the new instruction-attribution machinery added across `v2.36.0`–`v2.39.0`:
+  `capabilities/_merge.py`, `_on_event.py`, `abstract.py`'s `_collect_instruction_contributions`,
+  and `toolsets/abstract.py`'s parallel `_collect_instruction_contributions`/`_instruction_children`)
+  changed `WrapperToolset.get_instructions()` from `return await self.wrapped.get_instructions(ctx)`
+  (a bare passthrough of whatever the wrapped toolset returned) to
+  `flatten_instruction_contributions(...) or None`, which now returns
+  `list[InstructionPart]` instead of the wrapped toolset's raw `str`. `SkillsToolset.get_instructions()`
+  itself is unaffected (it isn't a `WrapperToolset` and its own return type — `str | None` — is
+  unchanged), but its composition helpers `.filtered()`, `.prefixed()`, `.prepared()`, `.renamed()`,
+  and `.approval_required()` all build `WrapperToolset` subclasses, and their `get_instructions()`
+  now returns a `list[InstructionPart]` rather than a plain string — still fully within the
+  `str | InstructionPart | Sequence[str | InstructionPart] | None` contract `AbstractToolset.get_instructions`
+  always declared, but two of this package's own tests
+  (`test_composition_wrappers_delegate_get_instructions`, `test_chained_composition_delegates_get_instructions`
+  in `tests/test_toolset.py`) asserted `'text' in prompt`, which broke once `prompt` became a list.
+  Fixed by adding a small `_instructions_text()` helper in `tests/test_toolset.py` that flattens
+  any of the three shapes to a string before the substring assertions; no source change was needed
+  since this is purely a pydantic-ai-side return-shape change within an already-declared contract.
+  Verified empirically: reproduced the failure on `pydantic-ai-slim==2.39.0` (7 failures — the 6
+  instruction-assertion tests plus the pre-existing `test_discover_skills_os_error_handling`
+  `chmod(0o000)`-as-root artifact), confirmed the fix brings it back to the single pre-existing
+  failure, and confirmed `pytest` passes identically (550 passed, same 1 pre-existing failure) on
+  both `pydantic-ai-slim==2.39.0` (latest) and `pydantic-ai-slim==1.105.0` (the declared floor) —
+  the test helper works unchanged against the floor's plain-`str` return too. `pre-commit run
+  --all-files` (ruff, ruff-format, mypy) is clean.
+
+  Everything else in this window was checked and found not to reach this package. The private
+  symbols this package imports — `pydantic_ai._function_schema.FunctionSchema`/`function_schema`
+  (`v2.36.0`–`v2.39.0` renamed several *other* private helpers in that module, `_is_call_ctx`→
+  `is_call_ctx`, `_extract_return_schema_type`→`extract_return_schema_type`, `_takes_ctx`→
+  `takes_ctx`, none of which this package imports; `function_schema()`'s signature and
+  `FunctionSchema`'s fields are byte-for-byte unchanged), `pydantic_ai._griffe.doc_descriptions`
+  (`_griffe.py` has zero diff across the whole window), and `pydantic_ai._utils.is_async_callable`/
+  `run_in_executor` (`_utils.py` only gained two unrelated new helpers, `own_annotations`/
+  `declares_dataclass_fields`, for Python 3.14 lazy-annotation support; the two functions this
+  package calls are byte-for-byte unchanged) — are all confirmed unchanged in signature and
+  behavior. `v2.38.0`'s Compatibility Notes item `#7248` ("Give one-off capabilities a default `id`
+  and a `combine` rule for repeats") and `v2.39.0`'s `#8047` ("Restore capability composition
+  invariants") both looked directly relevant to `SkillsCapability` on their titles alone, so were
+  read in full: `#7248` only gives *specific built-in* capabilities (`ImageGeneration`,
+  `WebSearch`, `Thinking`, etc.) a non-`None` default `id` so two of the same built-in collapse
+  into one; `AbstractCapability.id`'s own default stays `None`
+  (`capabilities/abstract.py:270`), `SkillsCapability` doesn't set a default `id` either, so the
+  new `combine()`/dedup machinery is simply never triggered for it (confirmed by grep across
+  `capabilities/*.py` for `id: str | None = '...'` — `SkillsCapability` isn't among them). `#8047`'s
+  fix is scoped to `WrapperCapability` (transparent capability wrappers like `prefix_tools()` that
+  retain their wrapped capability's `id` across agent/run layers) — `SkillsCapability` is a
+  standalone dataclass extending `AbstractCapability` directly, not a `WrapperCapability`, and
+  doesn't retain another capability's `id`, so it's outside what that PR touches. `v2.38.0`'s
+  `#6258` (typed `CustomEvent`/`CapabilityEvent`s dispatched via `@on_event`) is a new capability
+  hook this package could in principle use for event-driven behavior, but nothing in
+  `SkillsToolset`/`SkillsCapability` currently emits or needs to subscribe to run events, so no
+  action. The remaining `v2.36.0`–`v2.39.0` items (`@durable_operation` and Temporal/DBOS/Prefect
+  durable-execution support, `RealtimeSession`/voice changes, AG-UI event and `CancellationToken`
+  handling, new model providers — GLM-5.3, Gemini 3.8, Claude Fable 5.1/Mythos 5.1, `gpt-6-astra`,
+  `VLLMProvider` — span/instrumentation and pruned-span-query fixes, Bedrock/DeepSeek/XAI/Google/
+  Azure/Together provider-specific fixes) touch model providers, durable-execution engines, and
+  telemetry this package doesn't use. `pydantic-ai-harness` `v0.28.0`–`v0.29.0` (durable/replay-safe
+  `SummarizingCompaction`, `StepPersistence`, `SpendLimits`, journaled capability reads,
+  `AWSLambdaDurability`, instruction-part spacing between capabilities) are entirely
+  harness-internal — this package has no dependency on `pydantic-ai-harness`, so these are tracked
+  but out of scope as usual.
+
 ## 2026-08-28
 
 - **pydantic/pydantic-ai**: checked through `v2.35.3` (published 2026-08-28). Reviewed

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -5,8 +5,22 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from pydantic_ai.messages import InstructionPart
 
 from pydantic_ai_skills import SkillsToolset
+
+
+def _instructions_text(prompt: str | InstructionPart | Any) -> str:
+    """Flatten a get_instructions() result (str, InstructionPart, or a sequence of either) into text.
+
+    pydantic-ai's composition wrappers (filtered/prefixed/prepared/renamed/approval_required) may
+    return any of these shapes.
+    """
+    if isinstance(prompt, str):
+        return prompt
+    if isinstance(prompt, InstructionPart):
+        return prompt.content
+    return '\n'.join(part if isinstance(part, str) else part.content for part in prompt)
 
 
 @pytest.fixture
@@ -449,9 +463,10 @@ async def test_composition_wrappers_delegate_get_instructions(
     prompt = await composed_toolset.get_instructions(Mock())
 
     assert prompt is not None, f'{name} wrapper returned no instructions'
-    assert 'skill-one' in prompt
-    assert 'skill-two' in prompt
-    assert 'skill-three' in prompt
+    text = _instructions_text(prompt)
+    assert 'skill-one' in text
+    assert 'skill-two' in text
+    assert 'skill-three' in text
 
 
 @pytest.mark.asyncio
@@ -468,7 +483,7 @@ async def test_chained_composition_delegates_get_instructions(sample_skills_dir:
 
     prompt = await composed.get_instructions(Mock())
     assert prompt is not None
-    assert 'First test skill for basic operations' in prompt
+    assert 'First test skill for basic operations' in _instructions_text(prompt)
 
 
 def test_exclude_tools_empty_list(sample_skills_dir: Path) -> None:


### PR DESCRIPTION
- Closes #N/A

## Summary

Weekly upstream watch. Reviewed pydantic-ai `v2.36.0`–`v2.39.0` and pydantic-ai-harness `v0.28.0`–`v0.29.0` (releases since the last entry, which checked through `v2.35.3` / `v0.27.0`).

### Releases reviewed

**pydantic/pydantic-ai**
- [v2.36.0](https://github.com/pydantic/pydantic-ai/releases/tag/v2.36.0) — `@durable_operation` for capabilities, `InstructionPart.id`, `TestModel`/Prefect fixes. Not used here.
- [v2.37.0](https://github.com/pydantic/pydantic-ai/releases/tag/v2.37.0) — GLM-5.3 model, span/AG-UI/Vertex/DBOS/Prefect fixes. Not used here.
- [v2.38.0](https://github.com/pydantic/pydantic-ai/releases/tag/v2.38.0) — **the actionable one**: among other things, changed `WrapperToolset.get_instructions()` (base class behind `SkillsToolset`'s `.filtered()`/`.prefixed()`/`.prepared()`/`.renamed()`/`.approval_required()` composition helpers) from a bare passthrough of the wrapped toolset's return value to `flatten_instruction_contributions(...) or None`, which now returns `list[InstructionPart]` instead of the wrapped toolset's raw `str`. Also includes `#7248` "Give one-off capabilities a default `id` and a `combine` rule for repeats" — reviewed in full since it sounded capability-composition-relevant; doesn't reach `SkillsCapability` (see below).
- [v2.39.0](https://github.com/pydantic/pydantic-ai/releases/tag/v2.39.0) — includes `#8047` "Restore capability composition invariants" — also reviewed in full for the same reason; scoped to `WrapperCapability` (transparent capability wrappers), which `SkillsCapability` is not.

**pydantic/pydantic-ai-harness**
- [v0.28.0](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.28.0), [v0.28.1](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.28.1), [v0.29.0](https://github.com/pydantic/pydantic-ai-harness/releases/tag/v0.29.0) — durable/replay-safe `SummarizingCompaction`, `StepPersistence`, `SpendLimits`, `AWSLambdaDurability`, journaled capability reads. Entirely harness-internal; this package has no dependency on `pydantic-ai-harness`, tracked but out of scope as always.

### What changed and why

`SkillsToolset.get_instructions()` itself is untouched (it isn't a `WrapperToolset`, and its own `str | None` return type is unchanged). But its composition helpers build `WrapperToolset` subclasses, and two tests in `tests/test_toolset.py` — `test_composition_wrappers_delegate_get_instructions` and `test_chained_composition_delegates_get_instructions` — asserted `'text' in prompt` assuming `prompt` was a plain `str`. Against `pydantic-ai-slim>=2.38.0` that assertion now fails a `TypeError`-adjacent way (`'x' in list[InstructionPart]` doesn't raise, it just never matches), because the wrapper now returns `list[InstructionPart]` — still fully inside the `str | InstructionPart | Sequence[str | InstructionPart] | None` contract `AbstractToolset.get_instructions` always declared, just a different (also-valid) shape.

Fixed by adding a small `_instructions_text()` helper in `tests/test_toolset.py` that flattens any of the three shapes to a string before the substring assertions. No production code changed — this is a test-only fix for a pydantic-ai-side return-shape change within an already-declared contract.

Full triage notes (including why `#7248` and `#8047` don't apply, and private-symbol confirmation) are in the new `.github/upstream-watch.md` entry.

### Verification

- `pip install -e ".[test,git,s3,dev]"` — ran.
- `pytest` (via `python3 -m pytest`, since a stale `pytest` 9.0.2 shadows the freshly installed 9.1.1 on `$PATH` in this environment) — **before the fix**: 7 failed (the 6 instruction-assertion tests + the pre-existing `test_discover_skills_os_error_handling` artifact), 544 passed, on `pydantic-ai-slim==2.39.0`. **After the fix**: 550 passed, 1 failed (only the pre-existing `chmod(0o000)`-as-root artifact, unrelated to pydantic-ai and present before this PR too) — identical on both `pydantic-ai-slim==2.39.0` (latest) and `pydantic-ai-slim==1.105.0` (the declared floor).
- `pre-commit run --all-files` (ruff, ruff-format, mypy) — clean (ruff auto-fixed one import-ordering nit in the new test helper, included in this diff).

`.github/upstream-watch.md` is updated in this PR with the tags checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wei6ksqYcoyUFDfsrrbsia

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wei6ksqYcoyUFDfsrrbsia)_