### PR TITLE
feat: add SonarQube CLI skill

### DIFF
--- a/skills/sonarqube/SKILL.md
+++ b/skills/sonarqube/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: sonarqube
+description: >-
+  Operate SonarQube-enabled repositories through the SonarQube CLI (`sonar`): verify authentication, discover project
+  keys, inspect project metadata, issues, measures, and quality gates, analyze changed code, scan secrets and dependency
+  risks, call authenticated APIs, trigger remediation, configure integrations, and troubleshoot the CLI. Use whenever
+  the user mentions SonarQube, SonarQube Cloud/SonarCloud, Sonar project details, quality gates, Sonar issues, `sonar`
+  commands, agentic analysis, dependency risks, secrets scanning, or Sonar integrations, even if they do not explicitly
+  name this skill. Do not use for generic static analysis unrelated to SonarQube.
+compatibility: >-
+  Requires the SonarQube CLI executable `sonar`; commands were verified against v1.7.0. Some operations require Git, a
+  SonarQube Cloud plan or Server edition, or product-specific entitlements.
+---
+
+# SonarQube CLI
+
+Use the installed `sonar` CLI as the source of truth for a SonarQube-enabled project. Prefer structured, read-only inspection before analysis or mutation, and make the final response state the project, branch or pull request, command scope, and result.
+
+## Start with a preflight
+
+Run these checks from the repository or worktree the user placed in scope:
+
+```bash
+command -v sonar
+sonar --version
+sonar auth status
+```
+
+If the task involves installation state, integrations, or a confusing auth error, also run `sonar system status --json`.
+
+Treat `sonar auth status` as the authoritative credential check. Do not infer authentication merely from a saved config file. In a sandbox, container, SSH session, or background agent, OS Keychain access may fail even though authentication works in the user's interactive terminal. Explain that distinction and use the environment-variable route in [authentication.md](references/authentication.md) when the user has made credentials available; never retrieve, print, or persist a token yourself.
+
+The CLI is evolving. If the installed version differs from the reference snapshot or a command rejects an option, run `sonar --help` and `sonar <command> --help`, then follow the installed help. Read [commands.md](references/commands.md) when selecting flags or when the user asks what the CLI supports.
+
+## Resolve the project before querying it
+
+Use the exact project key, not the display name. Resolve it in this order:
+
+1. Use a project key explicitly supplied by the user.
+2. Inspect `sonar.projectKey` in `sonar-project.properties` at the repository root.
+3. Inspect SonarQube for IDE connected-mode binding under `.sonarlint/`, such as `.sonarlint/connectedMode.json`.
+4. Let the CLI auto-detect when the command supports it.
+5. Search accessible projects with `sonar list projects -q <name-or-key>` and disambiguate multiple matches before continuing.
+
+Do not silently choose among multiple project matches. Read [workflows.md](references/workflows.md) for project-detail, issue, quality-gate, and API recipes.
+
+## Choose the correct analysis
+
+| Intent | Command | Important behavior |
+| --- | --- | --- |
+| Analyze one or more changed source files | `sonar analyze --file <path>` | One file defaults to `STANDARD`; multiple files default to `DEEP`. `--file` is repeatable. |
+| Analyze uncommitted Git changes | `sonar analyze` | Requires a Git repository and may run server-side analysis. |
+| Analyze staged files | `sonar analyze --staged` | Uses `git diff --cached`. |
+| Compare with a base ref | `sonar analyze --base <ref>` | Analyze the change set relative to the named ref. |
+| Request explicit cross-file analysis | `sonar analyze --depth DEEP` | More context and potentially more time/data transfer. |
+| Invoke the explicit Vortex route | `sonar analyze agentic ...` | Server-side analysis; limitations and entitlements apply. |
+| Scan files for hardcoded secrets | `sonar analyze secrets <paths...>` | Scans paths or `--stdin`; treat a findings exit code as a finding, not an infrastructure failure. |
+| Analyze dependency manifests | `sonar analyze dependency-risks` | Uploads manifests for security/license analysis; product entitlement may be required. |
+| Run a traditional full-project CI scan | Project's existing scanner/build command | `sonar analyze` is not a replacement for every SonarScanner, Maven, Gradle, or .NET full-project pipeline. Inspect repository config and use the existing workflow only when requested. |
+
+Before server-side analysis, inspect the selected files or Git change set so the scope is known. Avoid `--force` unless the user has explicitly accepted bypassing the large-change-set confirmation. Prefer `--format json` for deterministic parsing and retain the command exit status.
+
+After fixing findings, rerun the same analysis scope. Do not expand from a file scan to the entire change set without saying so.
+
+If the selected Git scope is empty, report that no files were analyzed. An empty change set is not evidence that the repository is clean.
+
+## Prefer dedicated read commands
+
+Use the narrowest command that answers the question:
+
+```bash
+sonar list projects -q <query>
+sonar list issues --project <key> --format json
+sonar quality-gate status --project <key> --format json --all
+```
+
+Add exactly one of `--branch <name>` or `--pull-request <id>` when needed. They are mutually exclusive for quality-gate status. Paginate project and issue results rather than assuming the first page is complete.
+
+For an agent-facing issue summary, `--format toon` is compact. Use JSON when filtering, joining, or producing exact counts; use table or CSV only when that presentation is requested.
+
+Use `sonar api get ...` when dedicated commands do not expose enough detail. Start with read-only GET requests and consult the connected instance's API description when endpoint support is uncertain:
+
+```bash
+sonar api get "/api/webservices/list"
+```
+
+API v1/v2 availability differs by Cloud region and Server version. The CLI rewrites supported v2 paths between Cloud and Server, but the server remains the authority. URL-encode project keys and other user-controlled query values.
+
+## Handle state-changing commands deliberately
+
+These commands can change local files, credentials, CLI state, code, or remote SonarQube state:
+
+- `sonar remediate`
+- `sonar api post|patch|put|delete ...`
+- `sonar integrate ...`
+- `sonar auth login|logout`
+- `sonar config telemetry ...`
+- `sonar update`
+- `sonar system reset`
+
+Resolve exact targets and explain the effect before running them. Browser login must be performed manually by the user; agents cannot authenticate themselves. Never pass tokens in command arguments, logs, committed files, or chat output.
+
+For `sonar remediate`, preview eligible issue keys with `sonar list issues`, limit the selection to the requested issues, and note that non-interactive use requires `--issues` with at most 20 comma-separated keys.
+
+For `sonar integrate`, inspect existing hooks and agent configuration first because the command writes project or global configuration. Use `--non-interactive` only after all choices are known. Do not combine project selection with global mode where the installed help marks them mutually exclusive.
+
+Treat `sonar system reset --force` as destructive: it removes tokens, managed binaries, integrations, and cached files. Run it only when the user explicitly asks for a reset. Likewise, run `sonar auth logout`, telemetry changes, or an update only on explicit request.
+
+## Report results clearly
+
+For inspection tasks, report:
+
+- CLI version and authenticated target without exposing credentials
+- resolved project key and how it was resolved
+- branch or pull request scope
+- the requested result, including pagination or filters
+- any product/edition limitation or incomplete API response
+- a compact `Queries run` list naming the dedicated commands and GET endpoints used, so the result is auditable without exposing credentials
+
+For analysis tasks, report files/change-set scope, depth, issue counts grouped usefully, exit status, and the next concrete remediation step. Never reproduce detected secret values; report only type and safe location metadata.
+
+## Troubleshoot methodically
+
+When a command fails:
+
+1. Run its `--help` and compare flags with the installed version.
+2. Recheck `sonar auth status` and `sonar system status --json`.
+3. Confirm Cloud region or Server URL, organization, exact project key, branch/PR, and permissions.
+4. Distinguish authentication, entitlement/edition, network/proxy/TLS, Git-scope, and no-findings outcomes.
+5. Use `sonar api ... --verbose` only when needed and redact sensitive request or response data before reporting it.
+
+Read [authentication.md](references/authentication.md) for credential and network guidance, [workflows.md](references/workflows.md) for complete operational recipes, and [commands.md](references/commands.md) for the v1.7.0 command inventory.

--- a/skills/sonarqube/evals/evals.json
+++ b/skills/sonarqube/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "sonarqube",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm in a SonarQube-enabled repository. Check whether the CLI is authenticated, identify the exact Sonar project, and give me a concise project health summary with the latest quality gate, core measures, and open high-severity issues. Do not change anything.",
+      "expected_output": "A safe read-only workflow that checks the installed CLI and authentication, resolves the project key without guessing, queries project details/measures/quality gate/issues with structured output and pagination awareness, and reports scope and limitations without exposing credentials.",
+      "files": [],
+      "expectations": [
+        "Checks `sonar --version` and verifies authentication with `sonar auth status` before authenticated project queries.",
+        "Resolves and reports the exact project key without confusing it with a display name or silently choosing among multiple matches.",
+        "Uses dedicated read-only commands for projects, issues, and quality-gate status, plus authenticated GET API calls for measures or metadata.",
+        "Accounts for branch or pull-request scope and result pagination.",
+        "Does not run state-changing commands or expose authentication tokens."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Analyze only my staged changes with SonarQube, then explain the findings and the next fix to make. If the agent session cannot access my macOS Keychain even though I logged in earlier, handle that safely. Don't bypass any large-change warning.",
+      "expected_output": "A staged-change analysis workflow using `sonar analyze --staged`, with preflight scope inspection, safe auth handling for a sandboxed Keychain, structured results, no `--force`, no secret disclosure, and a same-scope rerun after remediation.",
+      "files": [],
+      "expectations": [
+        "Inspects the staged-file scope before running `sonar analyze --staged`.",
+        "Does not use `--force` and does not expand analysis beyond staged changes.",
+        "Explains Keychain isolation and either uses an explicitly approved read-only host credential check or the complete `SONARQUBE_CLI_TOKEN` plus Cloud organization/Server URL pairing, without printing or changing credentials.",
+        "Requests structured analysis output and preserves the command exit status.",
+        "Recommends rerunning the identical staged scope after fixes.",
+        "Does not claim the repository is clean when the staged change set is empty or analysis could not run."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Show me everything the installed SonarQube CLI can do, including auth, project and issue queries, quality gates, analysis modes, dependency risks, remediation, raw API access, integrations, context, telemetry, diagnostics, reset, and updates. Call out which operations are destructive or externally state-changing.",
+      "expected_output": "A complete, version-aware command inventory matching installed help, including all command groups, aliases and important options, while separating read-only operations from local/remote mutations and treating dynamic context actions accurately.",
+      "files": [],
+      "expectations": [
+        "Covers every v1.7.0 top-level command and documented subcommand: auth, analyze, remediate, list, quality-gate/qg, api, context, integrate, config, system, and update.",
+        "Includes analyze secrets, dependency-risks, and agentic; list issues/projects; auth login/logout/status; six integration targets; telemetry; system status/reset.",
+        "Explains that `sonar context` delegates to a separately installed component and discovers actions through installed help.",
+        "Marks credential changes, API mutation methods, remediation, integrations, telemetry changes, updates, and reset as state-changing, with reset destructive.",
+        "Uses installed `--help` as authority when the CLI version differs from the snapshot."
+      ]
+    }
+  ]
+}

--- a/skills/sonarqube/references/authentication.md
+++ b/skills/sonarqube/references/authentication.md
@@ -1,0 +1,71 @@
+# Authentication and environment
+
+## Interactive authentication
+
+Use `sonar auth status` to verify the active connection and token. `sonar auth login` opens a browser and saves credentials in the operating system keychain; it must be completed by the user, not an agent.
+
+```bash
+sonar auth login                                  # Cloud EU (default)
+sonar auth login --server https://sonarqube.us    # Cloud US
+sonar auth login --server https://sonarqube.example.com
+```
+
+For SonarQube Cloud, `--org <organization-key>` selects the organization. User tokens are required; project, global, or scoped organization tokens may not work for the CLI login workflow.
+
+`sonar auth logout` removes the active connection token and may revoke a CLI-created token server-side. Run logout only on explicit user request.
+
+## Automation and agent sessions
+
+Prefer environment variables in CI, containers, SSH sessions, background tasks, and coding-agent sandboxes because those environments may not have access to the user's OS Keychain.
+
+For SonarQube Cloud:
+
+```text
+SONARQUBE_CLI_TOKEN=<secret user token>
+SONARQUBE_CLI_ORG=<organization key>
+```
+
+For self-hosted SonarQube Server:
+
+```text
+SONARQUBE_CLI_TOKEN=<secret user token>
+SONARQUBE_CLI_SERVER=https://sonarqube.example.com
+```
+
+Set the complete pair. A token without its organization or server selector may cause the CLI to fall back to keychain credentials. Use a secret store or another user-approved injection mechanism. Never place tokens in tracked files, command-line arguments, or output.
+
+After environment injection, verify without printing variables:
+
+```bash
+sonar auth status
+sonar system status --json
+```
+
+Cloud EU is `https://sonarcloud.io`; Cloud US is `https://sonarqube.us`. An organization key is required for Cloud operations, while self-hosted automation requires its Server URL.
+
+## Network and telemetry
+
+`sonar system status --json` reports effective proxy, CA certificate, and client-certificate state with credentials redacted. Use it before guessing at TLS or connectivity failures.
+
+The CLI supports enterprise proxy, custom CA, and mutual-TLS configuration through environment variables. Because the exact variable set is version-dependent, inspect the current official environment-variable documentation or installed CLI status rather than inventing names.
+
+Telemetry and error reporting share the persisted toggle:
+
+```bash
+sonar config telemetry --enabled
+sonar config telemetry --disabled
+```
+
+Use `DO_NOT_TRACK=1` to disable telemetry for one process/session without changing persisted configuration. Change telemetry only when requested.
+
+## Common failures
+
+- **Keychain unavailable:** If an agent is unauthenticated while the user's terminal works, explain process isolation and offer environment-variable auth. Do not ask the user to log in repeatedly.
+- **Invalid token:** Confirm a non-expired user token, intended Cloud region/organization or Server, and project access.
+- **Correct auth, missing project:** Run `sonar list projects -q <query>`, verify the exact key, and check Browse/analysis permissions.
+
+## Sources
+
+- [SonarQube CLI README](https://github.com/SonarSource/sonarqube-cli/blob/master/README.md)
+- [SonarQube CLI command reference for agents](https://github.com/SonarSource/sonarqube-cli/blob/master/docs/llms.txt)
+- [SonarQube CLI quickstart](https://docs.sonarsource.com/sonarqube-cli/quickstart-guide)

--- a/skills/sonarqube/references/commands.md
+++ b/skills/sonarqube/references/commands.md
@@ -1,0 +1,143 @@
+# SonarQube CLI v1.7.0 command inventory
+
+Captured from installed `sonar` v1.7.0 help and SonarSource's v1.7.0 agent reference on 2026-09-05. Prefer installed `--help` when versions differ.
+
+## Global and authentication
+
+```text
+sonar --help
+sonar --version
+sonar <command> --help
+sonar auth login [-s|--server <server>] [-o|--org <org>]
+sonar auth logout
+sonar auth status
+```
+
+`login` uses browser authentication and the system keychain; agents cannot complete it for the user. Server selects a self-hosted URL, Cloud EU (`https://sonarcloud.io`, default), or Cloud US (`https://sonarqube.us`). Organization selects a Cloud organization. Logout removes the active connection token; status verifies it.
+
+## Analysis
+
+```text
+sonar analyze [options]
+sonar analyze agentic [options]
+```
+
+Shared scope options:
+
+- `--file <path>`: specific file, repeatable.
+- `--staged`: staged files (`git diff --cached`).
+- `--base <ref>`: files changed relative to a ref.
+- `-p, --project <project>`: override detected project key.
+- `--force`: skip large-change confirmation.
+- `--depth STANDARD|DEEP`: one-file default STANDARD; otherwise DEEP.
+- `--format text|json`: default text.
+
+`sonar analyze agentic` also has `--branch <branch>` and invokes server-side Vortex analysis.
+
+```text
+sonar analyze secrets [--stdin] [paths...]
+```
+
+Paths may be files/directories; `--stdin` reads standard input.
+
+```text
+sonar analyze dependency-risks [options]
+```
+
+- `-p, --project <project>`: auto-detected if omitted.
+- `--format json|toon|table`: default table.
+- `--statuses <statuses>`: raw values/presets, comma-separated.
+- `--min-severity BLOCKER|HIGH|MEDIUM|LOW|INFO`.
+
+Raw statuses: `new`, `open`, `confirm`, `accept`, `safe`, `fixed`. Presets: `active` = new/open/confirm; `to_fix` adds accept; `all` includes every status. Values combine as a union.
+
+## Remediation
+
+```text
+sonar remediate [-p|--project <project>] [--issues <issueIds>]
+```
+
+Cloud-only. `--issues` accepts at most 20 comma-separated keys and is required without a TTY.
+
+## Projects and issues
+
+```text
+sonar list projects [-q|--query <query>] [--page <number>] [--page-size <1-500>]
+sonar list issues [options]
+```
+
+Issue options:
+
+- `-p, --project <project>`
+- `--statuses OPEN,CONFIRMED,FALSE_POSITIVE,ACCEPTED,FIXED`
+- `--severities <comma-separated values appropriate to server mode>`
+- `--format json|toon|table|csv` (default JSON)
+- `--branch <branch>`
+- `--pull-request <id>`
+- `--page-size <1-500>` (default 500)
+- `--page <number>` (default 1)
+
+## Quality gate
+
+```text
+sonar quality-gate status [options]
+sonar qg status [options]
+```
+
+The names are aliases. Options: `-p|--project`, `--format json|table`, exactly one of `--branch`/`--pull-request`, and `--all` to include passing conditions.
+
+## Authenticated Web API
+
+```text
+sonar api [-d|--data <json>] [-v|--verbose] <method> <endpoint>
+```
+
+Methods: `get`, `post`, `patch`, `put`, `delete`. Endpoint starts with `/` and may contain query parameters. `--data` is a JSON string; the CLI chooses form or JSON body. The CLI adapts supported v1/v2 paths between Cloud and Server.
+
+## Integrations
+
+```text
+sonar integrate git [options]
+sonar integrate claude [options]
+sonar integrate copilot [options]
+sonar integrate codex [options]
+sonar integrate antigravity [options]
+sonar integrate cursor [options]
+```
+
+Git options: `--hook pre-commit|pre-push`, `--force`, `--non-interactive`, `--global`, `--dependency-risks`, and `-p|--project`. Dependency risks require a project and are not supported globally.
+
+Agent options: `-p|--project`, `--non-interactive`, `-g|--global`. Inspect installed help for project/global exclusivity.
+
+Effects by target:
+
+- `claude`: secrets hooks, Vortex analysis, MCP Server.
+- `copilot`: secrets hooks, Vortex analysis, MCP Server.
+- `codex`: UserPromptSubmit secret-scanning hook.
+- `antigravity`: secrets hooks, prompt-secret instructions, Vortex Context.
+- `cursor`: MCP Server, secrets hooks, Vortex analysis.
+
+## Context Augmentation
+
+```text
+sonar context [action] [args...]
+```
+
+Passthrough to the separately installed `sonar-context-augmentation` binary. Bare invocation and `--help` are forwarded. Eligible project-scoped integrations install it; the wrapper does not auto-install it. Discover actions dynamically with `sonar context --help`.
+
+## Configuration, diagnostics, reset, and update
+
+```text
+sonar config telemetry --enabled
+sonar config telemetry --disabled
+sonar system status [--json]
+sonar system reset [--force]
+sonar update [--status] [--force]
+```
+
+System status covers auth, binaries, integrations, cache, network, health, and recommendations. Reset removes tokens, managed binaries, integrations, and caches while preserving telemetry settings. Update status is read-only; bare update installs latest; update force reinstalls latest.
+
+## Sources
+
+- [Current agent command reference](https://raw.githubusercontent.com/SonarSource/sonarqube-cli/master/docs/llms.txt)
+- [Interactive command reference](https://sonarsource.com/sonarqube/cli/commands.html)

--- a/skills/sonarqube/references/workflows.md
+++ b/skills/sonarqube/references/workflows.md
@@ -1,0 +1,126 @@
+# Operational workflows
+
+## Project discovery and details
+
+```bash
+sonar list projects
+sonar list projects --query <name-or-key> --page 1 --page-size 500
+```
+
+The output is JSON. Use the exact `projects[].key`, not the display name. Continue pagination while another page exists.
+
+Combine dedicated commands with read-only API calls for a project snapshot:
+
+```bash
+sonar api get "/api/components/show?component=<URL_ENCODED_PROJECT_KEY>"
+sonar api get "/api/measures/component?component=<URL_ENCODED_PROJECT_KEY>&metricKeys=ncloc,coverage,duplicated_lines_density,bugs,vulnerabilities,code_smells,security_hotspots"
+sonar quality-gate status --project <PROJECT_KEY> --format json --all
+sonar api get "/api/project_analyses/search?project=<URL_ENCODED_PROJECT_KEY>&ps=20"
+sonar api get "/api/project_branches/list?project=<URL_ENCODED_PROJECT_KEY>"
+```
+
+Endpoint and metric availability vary by Cloud/Server version and permissions. If unavailable, inspect `/api/webservices/list` or the instance's Web API page. Do not treat a missing metric as zero.
+
+Summarize returned key/name/visibility, analysis date and branch/PR, quality-gate verdict and failed conditions, core measures, and issue counts under the stated filters.
+
+## Issues and quality gate
+
+```bash
+sonar list issues --project <PROJECT_KEY> --format json
+sonar list issues --project <PROJECT_KEY> --statuses OPEN,CONFIRMED --severities HIGH,BLOCKER --format toon
+sonar list issues --project <PROJECT_KEY> --branch <BRANCH> --page 1 --page-size 500 --format json
+sonar list issues --project <PROJECT_KEY> --pull-request <PR_ID> --format json
+
+sonar quality-gate status --project <PROJECT_KEY> --format json --all
+sonar qg status --project <PROJECT_KEY> --branch <BRANCH> --format table --all
+sonar quality-gate status --project <PROJECT_KEY> --pull-request <PR_ID> --format json --all
+```
+
+`quality-gate` and `qg` are aliases. Branch and pull request are mutually exclusive. Without `--all`, only failed conditions appear.
+
+Issue severities depend on mode: MQR uses `INFO`, `LOW`, `MEDIUM`, `HIGH`, `BLOCKER`; Standard Experience uses `INFO`, `MINOR`, `MAJOR`, `CRITICAL`, `BLOCKER`. Status filters are `OPEN`, `CONFIRMED`, `FALSE_POSITIVE`, `ACCEPTED`, and `FIXED`.
+
+## Changed-code analysis
+
+Inspect scope first:
+
+```bash
+git status --short
+git diff --name-only
+git diff --cached --name-only
+```
+
+Then choose one scope:
+
+```bash
+sonar analyze --file src/example.py --format json
+sonar analyze --file src/a.py --file src/b.py --depth DEEP --format json
+sonar analyze --staged --format json
+sonar analyze --base main --format json
+sonar analyze --project <PROJECT_KEY> --format json
+sonar analyze agentic --project <PROJECT_KEY> --branch <BRANCH> --format json
+```
+
+`STANDARD` is optimized for a narrow file check; `DEEP` provides cross-file context. One `--file` defaults to STANDARD; other scopes default to DEEP. `--force` bypasses large-change confirmation and should not be used casually.
+
+This may send relevant code to server-side analysis. For a traditional full-project scan that publishes a complete analysis, inspect build/CI files for the existing SonarScanner command. Do not substitute `sonar analyze` without confirming intent.
+
+## Secrets and dependency risks
+
+```bash
+sonar analyze secrets src/config.ts
+sonar analyze secrets src/ scripts/
+sonar analyze secrets --stdin
+
+sonar analyze dependency-risks --project <PROJECT_KEY> --format json
+sonar analyze dependency-risks --statuses active --min-severity HIGH --format toon
+sonar analyze dependency-risks --statuses to_fix --format table
+```
+
+With secrets, positional arguments are file/directory paths and `--stdin` reads standard input. A findings-specific nonzero exit means secrets were detected, not necessarily a crash. Never repeat secret values.
+
+Dependency raw statuses are `new`, `open`, `confirm`, `accept`, `safe`, `fixed`. Presets: `active` = new/open/confirm; `to_fix` adds accept; `all` includes every status. Values combine as a union. Manifests are uploaded to SonarQube; SCA entitlement/edition requirements apply.
+
+## Remediation
+
+Preview eligible issues, resolve exact keys, then run only with user intent:
+
+```bash
+sonar remediate --project <PROJECT_KEY> --issues <ISSUE_KEY_1>,<ISSUE_KEY_2>
+```
+
+Non-interactive use requires `--issues` and accepts at most 20 keys. This is Cloud-only. Review local edits and rerun the same analysis scope.
+
+## Authenticated API
+
+```bash
+sonar api <get|post|patch|put|delete> "/endpoint?query=value"
+sonar api post "/endpoint" --data '{"field":"value"}'
+sonar api get "/api/webservices/list"
+sonar api get "/api/system/status"
+sonar api get "/api/favorites/search"
+```
+
+The endpoint starts with `/`. The CLI selects form or JSON encoding and adapts supported v1/v2 routing. Use GET by default; POST/PATCH/PUT/DELETE are remote mutations. Never create or return tokens unless explicitly requested and secure delivery exists. Use `--verbose` only for debugging and redact output.
+
+## Integrations and context
+
+Inspect target help and existing config before running `sonar integrate git|claude|copilot|codex|antigravity|cursor`. Git supports pre-commit/pre-push; dependency-risk pre-commit requires a project and is not global. Agent targets may install hooks, MCP config, Vortex analysis, and Context Augmentation. Prefer project-specific installation for one repository; global installation changes user-wide config.
+
+`sonar context [action] [args...]` passes through to the separately installed Context Augmentation binary. Discover actions using `sonar context --help` after an eligible project-scoped agent integration. Do not invent actions from older releases.
+
+## Diagnostics and maintenance
+
+```bash
+sonar system status --json
+sonar update --status
+```
+
+`sonar update` installs software. `sonar system reset` removes credentials, managed binaries, integrations, and caches while preserving telemetry settings. Neither should be run as a troubleshooting experiment without explicit authorization.
+
+## Sources
+
+- [SonarQube CLI v1.7.0 command reference](https://raw.githubusercontent.com/SonarSource/sonarqube-cli/master/docs/llms.txt)
+- [SonarQube CLI README](https://github.com/SonarSource/sonarqube-cli/blob/master/README.md)
+- [SonarQube Cloud Web API](https://docs.sonarsource.com/sonarqube-cloud/appendices/web-api)
+- [SonarQube Server Web API](https://docs.sonarsource.com/sonarqube-server/extension-guide/web-api)


### PR DESCRIPTION
## Summary

- add a reusable SonarQube CLI skill for authenticated project workflows
- document the complete v1.7.0 command surface, including analysis, quality gates, API access, integrations, and maintenance
- add safe authentication, project discovery, analysis, remediation, and troubleshooting guidance
- include behavioral evaluation definitions

## Validation

- skill-creator quick validation passed
- JSON validation passed
- git diff --check passed
- repository pre-commit hooks passed