### PR TITLE
ci: retry setup-uv so one dropped fetch cannot fail a run

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -1,0 +1,55 @@
+name: "Set up uv"
+description: >-
+  astral-sh/setup-uv, retried. Resolving the uv version and its download URL both
+  go through a single un-retried fetch of the astral-sh/versions manifest on
+  raw.githubusercontent.com, so one dropped request fails the step and kills the
+  job before it installs anything.
+
+inputs:
+  version:
+    description: >-
+      uv version to install. Empty (the default) means the version in uv.toml or
+      pyproject.toml, falling back to latest.
+    default: ""
+  enable-cache:
+    description: "Passed through to astral-sh/setup-uv."
+    default: "auto"
+
+runs:
+  using: composite
+  steps:
+    - id: attempt-1
+      uses: astral-sh/setup-uv@v7
+      continue-on-error: true
+      with:
+        version: ${{ inputs.version }}
+        enable-cache: ${{ inputs.enable-cache }}
+
+    - if: steps.attempt-1.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "::warning::setup-uv failed. Retrying in 5s."
+        sleep 5
+
+    - id: attempt-2
+      if: steps.attempt-1.outcome == 'failure'
+      uses: astral-sh/setup-uv@v7
+      continue-on-error: true
+      with:
+        version: ${{ inputs.version }}
+        enable-cache: ${{ inputs.enable-cache }}
+
+    - if: steps.attempt-1.outcome == 'failure' && steps.attempt-2.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "::warning::setup-uv failed twice. Retrying in 15s."
+        sleep 15
+
+    # No continue-on-error on the last attempt: three failures spread over ~20s is
+    # an upstream outage or a real misconfiguration, not a dropped packet, and the
+    # job should fail with setup-uv's own error rather than a later missing-uv one.
+    - if: steps.attempt-1.outcome == 'failure' && steps.attempt-2.outcome == 'failure'
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: ${{ inputs.version }}
+        enable-cache: ${{ inputs.enable-cache }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,13 @@ updates:
         patterns:
           - "*"
 
+  # A `/` directory covers `.github/workflows/` and a root `action.yml` only, so the
+  # composite action under `.github/actions/` needs its own entry or the third-party
+  # action it pins never gets bumped.
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/setup-uv"
     schedule:
       interval: "monthly"
     cooldown:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ./.github/actions/setup-uv
 
       - name: Install dependencies
         run: uv pip install --system -e ".[test,git]"
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ./.github/actions/setup-uv
 
       - name: Install dependencies at their lowest declared versions
         run: uv pip install --system --resolution lowest-direct -e ".[test,git]"
@@ -134,7 +134,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ./.github/actions/setup-uv
 
       - name: Build sdist and wheel
         run: uv build
@@ -163,7 +163,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ./.github/actions/setup-uv
 
       - name: Install dependencies
         run: uv pip install --system -e ".[docs]"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/setup-uv
 
       - name: Install dependencies
         run: uv pip install --system -e ".[docs]"


### PR DESCRIPTION
## Summary

Fixes the failure in [run 34004368133](https://github.com/DougTrajano/pydantic-ai-skills/actions/runs/34004368133) — `Test (Python 3.11, deps latest)`.

**Root cause: nothing in this repository.** One of sixteen jobs lost a network race. The entire failure was:

```
Could not determine uv version from uv.toml or pyproject.toml. Falling back to latest.
Fetching version data from https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson ...
##[error]fetch failed
```

The fifteen sibling jobs on the same commit installed uv successfully in the same second, and the failing job died at `setup-uv` before installing a single dependency. `Check` then failed the run.

Reading `astral-sh/setup-uv@v7`:

- `determineVersion` finds no `version` input and no `[tool.uv] required-version`, so it resolves `latest` via `getLatestVersionFromNdjson()` — a fetch of the astral-sh/versions manifest.
- `src/utils/fetch.ts` is a bare undici `fetch` with **no retry**. One dropped request fails the step outright.
- Pinning a version would not fix this. `downloadVersionFromNdjson` → `getArtifact` fetches the *same* manifest to find the artifact URL even for an explicit version, so the network call stays on the critical path either way.

So the durable fix is a retry, which the action does not provide.

### What changed

- **New `.github/actions/setup-uv/action.yml`** — a local composite action that runs `astral-sh/setup-uv@v7` up to three times, pausing 5s then 15s. The first two attempts use `continue-on-error`; the last deliberately does not, so three failures over ~20s fail the job with setup-uv's own error rather than with a confusing `uv: command not found` later.
- **All five call sites** (4 in `ci.yml`, 1 in `gh-pages.yml`) now point at it.
- **`dependabot.yml`** — the `github-actions` ecosystem with `directory: "/"` fetches `.github/workflows/` and a *root* `action.yml` only (confirmed in `dependabot-core`'s `github_actions/file_fetcher.rb`), so the new file needs its own directory entry or the `astral-sh/setup-uv` pin inside it would silently stop being bumped.

The happy path is unchanged: the first attempt succeeds and the remaining steps skip. The action forwards `version` and `enable-cache` using setup-uv's own defaults (`""` and `"auto"`), so what CI installs today is unchanged.

### Verification

- `continue-on-error` on composite-action steps and `steps.<id>.outcome` are both documented and confirmed against the GitHub docs source.
- All four YAML files parse; `actionlint` reports nothing new. Its one finding (`ci.yml:78`, `github.event.pull_request.head.ref` used inline) is pre-existing on `main` and untouched here — worth a separate look.
- Whitespace/EOF hygiene checked by hand; `pre-commit` is not installed in this environment, so the lint job is the real check.

The retry path itself can only be exercised by an actual upstream failure, so CI here will only prove the happy path.

## Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] **Tests** added or updated for any behavior change (`pytest`) — n/a, CI configuration only; no package code changed.
- [ ] `pre-commit run --all-files` passes — not installed in this environment; verified `check-yaml`, `trailing-whitespace`, `end-of-file-fixer` and `mixed-line-ending` by hand.
- [x] Docs updated if behavior, configuration, or public API changed — n/a, no user-facing behavior changed.
- [x] New code works against the **floor** — n/a, no Python changed.
- [x] **PR title** is fit for the release changelog; please label `chore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNPLP8QhfaFEUuSmV3gQYS

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNPLP8QhfaFEUuSmV3gQYS)_